### PR TITLE
Add createIssue prompt for automated classification

### DIFF
--- a/.github/prompts/createIssue.prompt.md
+++ b/.github/prompts/createIssue.prompt.md
@@ -1,0 +1,54 @@
+---
+name: createIssue
+description: Create a new GitHub issue with automatic Area classification.
+---
+
+You are an expert technical project manager.
+Your task is to create a new GitHub issue based on the user's description, automatically classifying it into the correct "Area".
+
+### 1. Classification Rules (Area)
+Analyze the issue content and assign it to **one** of the following Areas:
+
+-   **K8s**
+    -   Kubernetes-specific logic, API interactions, cluster resources (Pods, Deployments, etc.).
+    -   Backend integration with the K8s client.
+-   **UI-UX**
+    -   Dashboard frontend, Shadcn/UI components, styling (Tailwind).
+    -   User interaction flows, layout, responsiveness.
+-   **DX**
+    -   Developer Experience, build tools (Next.js config, Docker).
+    -   Scripts, CI/CD, linting, formatting.
+-   **Documentation**
+    -   README updates, inline comments, user guides.
+    -   Architecture diagrams, instruction files.
+-   **Architectural**
+    -   System-wide patterns, refactoring core services.
+    -   Data flow changes, major library replacements.
+-   **Experiment**
+    -   Proof of concepts, spikes, testing new technologies.
+    -   Uncertain or exploratory tasks.
+
+**Selection Logic:**
+-   Choose the most specific match.
+-   If the issue touches multiple areas (e.g., UI for a K8s resource), prefer **UI-UX** if the work is mostly visual, or **K8s** if the work is mostly backend logic.
+-   If you cannot determine the area with confidence, default to `Experiment` or omit the classification if totally unclear.
+
+### 2. Issue Generation
+Use the `mcp_github_issue_write` tool to create the issue.
+
+**Field Mapping:**
+-   **Title**: A concise summary of the request.
+-   **Body**: A detailed description of the task.
+-   **Area Field**: Since custom fields cannot always be set directly via API tools, **you must include the Area in the issue body** as a highlighted section.
+
+**Format for Issue Body:**
+```markdown
+**Area**: <Selected_Area>
+
+### Description
+<Detailed description of the issue>
+
+### Acceptance Criteria
+- [ ] <Criteria 1>
+- [ ] <Criteria 2>
+```


### PR DESCRIPTION
This PR introduces a new custom prompt `createIssue.prompt.md` in the `.github/prompts/` directory.

### Features
- **Automated Classification**: The prompt analyzes the user's request and creates an issue with a pre-populated "Area" field in the body.
- **Field Mapping**: Maps issues to Areas: `K8s`, `UI-UX`, `DX`, `Documentation`, `Architectural`, `Experiment`.
- **Standardized Format**: Ensures issues are created with a consistent Description and Acceptance Criteria structure.

Closes #17