### PR TITLE
feat: add model selector to copilot chat

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -3,12 +3,12 @@ import { sendMessage } from "@/lib/copilot-service";
 
 export async function POST(req: NextRequest) {
   try {
-    const { message } = await req.json();
+    const { message, model } = await req.json();
     if (!message) {
         return NextResponse.json({ error: "Message is required" }, { status: 400 });
     }
 
-    const response = await sendMessage(message);
+    const response = await sendMessage(message, model);
     return NextResponse.json({ response });
   } catch (err: unknown) {
     console.error("Chat error:", err);

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getModels } from "@/lib/copilot-service";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const models = await getModels();
+    return NextResponse.json({ models });
+  } catch (err: unknown) {
+    console.error("Error fetching models:", err);
+    const message = err instanceof Error ? err.message : "Failed to fetch models";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/ChatComponent.tsx
+++ b/src/components/ChatComponent.tsx
@@ -9,7 +9,14 @@ import {
   X,
   MessageCircle,
   Loader2,
+  ChevronDown
 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 // Message type
 type Message = {
@@ -29,6 +36,8 @@ export default function ChatComponent({
   // If controlled, use prop; else manage local state
   const [isOpen, setIsOpen] = useState<boolean>(!!controlledIsOpen);
   const [messages, setMessages] = useState<Message[]>([]);
+  const [model, setModel] = useState("gpt-4o");
+  const [availableModels, setAvailableModels] = useState<{ id: string; name: string }[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -39,6 +48,26 @@ export default function ChatComponent({
   useEffect(() => {
     if (controlledIsOpen !== undefined) setIsOpen(controlledIsOpen);
   }, [controlledIsOpen]);
+
+  // Fetch available models
+  useEffect(() => {
+    async function fetchModels() {
+      try {
+        const res = await fetch("/api/models");
+        if (res.ok) {
+          const data = await res.json();
+          if (data.models && Array.isArray(data.models)) {
+             setAvailableModels(data.models);
+             // Verify if current default model exists in the list?
+             // Not strictly necessary, but good UX.
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch models", err);
+      }
+    }
+    fetchModels();
+  }, []);
 
   // Auto-scroll to bottom on new message
   useEffect(() => {
@@ -68,7 +97,7 @@ export default function ChatComponent({
       const res = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: userMsg.content }),
+        body: JSON.stringify({ message: userMsg.content, model }),
       });
 
       if (!res.ok) throw new Error("Failed to get response");
@@ -119,15 +148,63 @@ export default function ChatComponent({
           <MessageCircle className="w-5 h-5 text-blue-400" />
           <span className="font-semibold text-white text-lg">ST-K8s Chat</span>
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-zinc-400 hover:text-white"
-          onClick={handleToggle}
-          aria-label="Close chat"
-        >
-          <X className="w-5 h-5" />
-        </Button>
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1 bg-zinc-800 border-zinc-700 text-zinc-200 text-xs px-2 hover:bg-zinc-700 hover:text-white"
+              >
+                {model}
+                <ChevronDown className="h-3 w-3 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="bg-zinc-800 border-zinc-700 text-zinc-200 z-[70] max-h-60 overflow-y-auto">
+              {availableModels.length > 0 ? (
+                availableModels.map((m) => (
+                  <DropdownMenuItem
+                    key={m.id}
+                    onClick={() => setModel(m.id)}
+                    className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs"
+                  >
+                    {m.name}
+                  </DropdownMenuItem>
+                ))
+              ) : (
+                <>
+                  <DropdownMenuItem
+                    onClick={() => setModel("gpt-4o")}
+                    className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs"
+                  >
+                    GPT-4o
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => setModel("claude-3.5-sonnet")}
+                    className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs"
+                  >
+                    Claude 3.5 Sonnet
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => setModel("o1-mini")}
+                    className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs"
+                  >
+                    o1 Mini
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-zinc-400 hover:text-white"
+            onClick={handleToggle}
+            aria-label="Close chat"
+          >
+            <X className="w-5 h-5" />
+          </Button>
+        </div>
       </div>
 
       {/* Messages */}

--- a/src/lib/copilot-service.ts
+++ b/src/lib/copilot-service.ts
@@ -163,15 +163,36 @@ const listConfigMapsTool = defineTool("list_configmaps", {
 let client: CopilotClient | null = null;
 type CopilotSession = Awaited<ReturnType<CopilotClient["createSession"]>>;
 let session: CopilotSession | null = null;
+let currentModel: string | null = null;
 
-export async function getSession() {
-  if (session) return session;
+export async function getSession(model: string = "gpt-4o") {
+  console.log(`[CopilotService] getSession called with model: ${model}`);
+  console.log(`[CopilotService] Current active model: ${currentModel}`);
+  
+  if (session && currentModel === model) {
+    console.log(`[CopilotService] Reusing existing session for model: ${model}`);
+    return session;
+  }
+
+  // If we have an existing session but need a different model, destroy the old one
+  if (session) {
+    console.log(`[CopilotService] Destroying old session (model: ${currentModel}) to switch to ${model}`);
+    try {
+      await session.destroy();
+    } catch (err) {
+      console.warn("[CopilotService] Error destroying old session:", err);
+    }
+    session = null;
+  }
+
+  console.log(`[CopilotService] Creating NEW session for model: ${model}`);
 
   if (!client) {
     client = new CopilotClient({ logLevel: "info" });
   }
 
   session = await client.createSession({
+    model,
     tools: [
         listNamespacesTool,
         listPodsTool,
@@ -188,12 +209,14 @@ export async function getSession() {
         listConfigMapsTool
     ]
   });
+  currentModel = model;
+  console.log(`[CopilotService] Session created. currentModel updated to: ${currentModel}`);
 
   return session;
 }
 
-export async function sendMessage(message: string) {
-    const sess = await getSession();
+export async function sendMessage(message: string, model: string = "gpt-4o") {
+    const sess = await getSession(model);
     // Use sendAndWait as per example
     const result = await sess.sendAndWait({ prompt: message });
 
@@ -203,3 +226,22 @@ export async function sendMessage(message: string) {
 
     return result.data.content;
 }
+
+export async function getModels() {
+  if (!client) {
+    client = new CopilotClient({ logLevel: "info" });
+  }
+  
+  try {
+      if (client.getState() === "disconnected") {
+           await client.start();
+      }
+
+      const models = await client.listModels();
+      return models;
+  } catch (error) {
+      console.error("Failed to list models:", error);
+      return [];
+  }
+}
+


### PR DESCRIPTION
This PR adds support for selecting different LLM models in the Copilot chat interface.

Changes:
- Added a dropdown in `ChatComponent` to select models (e.g., GPT-4o, Claude 3.5 Sonnet).
- Created `/api/models` endpoint to list available models from Copilot SDK.
- Updated `copilot-service.ts` to handle session switching when the model changes.
- Updated `/api/chat` to accept the selected model.