### PR TITLE
Fix #37: Move Events button to bottom of Side Panel

### DIFF
--- a/src/app/k8s-dashboard/Sidebar.tsx
+++ b/src/app/k8s-dashboard/Sidebar.tsx
@@ -49,10 +49,10 @@ const TOOLS: { id: ToolType; label: string; icon: React.ReactNode }[] = [
   { id: "services", label: "Services", icon: <Network className="w-4 h-4" /> },
   { id: "ingresses", label: "Ingresses", icon: <Globe className="w-4 h-4" /> },
   { id: "endpoints", label: "Endpoints", icon: <Activity className="w-4 h-4" /> },
-  { id: "events", label: "Events", icon: <Activity className="w-4 h-4" /> },
   { id: "configmaps", label: "ConfigMaps", icon: <FileText className="w-4 h-4" /> },
   { id: "volumes", label: "Volumes (PVCs)", icon: <HardDrive className="w-4 h-4" /> },
   { id: "nodes", label: "Nodes", icon: <Cpu className="w-4 h-4" /> },
+  { id: "events", label: "Events", icon: <Activity className="w-4 h-4" /> },
 ];
 
 export default function Sidebar({


### PR DESCRIPTION
This PR moves the "Events" button to the bottom of the tool list in the Side Panel as requested in #37.

Changes:
- Reordered `TOOLS` array in `src/app/k8s-dashboard/Sidebar.tsx` to place "events" at the end.

Closes #37.