### PR TITLE
Add tests for missing K8s API routes

### DIFF
--- a/src/app/api/tools/k8s-daemonsets/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-daemonsets/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getDaemonSets: vi.fn()
+}))
+
+describe('API: k8s-daemonsets', () => {
+  it('returns daemonsets data on success', async () => {
+    const mockData = [{ 
+      name: 'test-ds', 
+      desired: 3, 
+      current: 3, 
+      ready: 3, 
+      available: 3,
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getDaemonSets).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-daemonsets?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getDaemonSets).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getDaemonSets).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-daemonsets')
+    await GET(req)
+    
+    expect(k8s.getDaemonSets).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getDaemonSets).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-daemonsets?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-deployments/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-deployments/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getDeployments: vi.fn()
+}))
+
+describe('API: k8s-deployments', () => {
+  it('returns deployments data on success', async () => {
+    const mockData = [{ 
+      name: 'test-deploy', 
+      replicas: 3,
+      readyReplicas: 3,
+      updatedReplicas: 3,
+      availableReplicas: 3,
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getDeployments).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-deployments?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getDeployments).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getDeployments).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-deployments')
+    await GET(req)
+    
+    expect(k8s.getDeployments).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getDeployments).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-deployments?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-endpoints/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-endpoints/__tests__/route.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getEndpoints: vi.fn()
+}))
+
+describe('API: k8s-endpoints', () => {
+  it('returns endpoints data on success', async () => {
+    const mockData = [{ 
+      name: 'test-ep', 
+      subsets: [],
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getEndpoints).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-endpoints?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getEndpoints).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getEndpoints).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-endpoints')
+    await GET(req)
+    
+    expect(k8s.getEndpoints).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getEndpoints).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-endpoints?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-events/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-events/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getEvents: vi.fn()
+}))
+
+describe('API: k8s-events', () => {
+  it('returns events data on success', async () => {
+    const mockData = [{ 
+      name: 'test-event', 
+      involvedObject: { kind: 'Pod', name: 'pod-1' },
+      message: 'test message',
+      reason: 'test reason',
+      source: 'test source',
+      type: 'Normal',
+      count: 1,
+      firstTimestamp: '2023-01-01',
+      lastTimestamp: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getEvents).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-events?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getEvents).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getEvents).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-events')
+    await GET(req)
+    
+    expect(k8s.getEvents).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getEvents).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-events?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-ingresses/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-ingresses/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getIngresses: vi.fn()
+}))
+
+describe('API: k8s-ingresses', () => {
+  it('returns ingresses data on success', async () => {
+    const mockData = [{ 
+      name: 'test-ing', 
+      class: 'nginx',
+      hosts: ['example.com'],
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getIngresses).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-ingresses?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getIngresses).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getIngresses).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-ingresses')
+    await GET(req)
+    
+    expect(k8s.getIngresses).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getIngresses).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-ingresses?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-namespaces/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-namespaces/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getNamespaces: vi.fn()
+}))
+
+describe('API: k8s-namespaces', () => {
+  it('returns namespaces data on success', async () => {
+    const mockData = ['default', 'kube-system']
+    vi.mocked(k8s.getNamespaces).mockResolvedValue(mockData)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-namespaces')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ namespaces: mockData })
+    expect(k8s.getNamespaces).toHaveBeenCalled()
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getNamespaces).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-namespaces')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-nodes/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-nodes/__tests__/route.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getNodes: vi.fn()
+}))
+
+describe('API: k8s-nodes', () => {
+  it('returns nodes data on success', async () => {
+    const mockData = [{ 
+      name: 'node-1', 
+      status: 'Ready',
+      role: 'worker',
+      version: 'v1.20.0'
+    }]
+    vi.mocked(k8s.getNodes).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-nodes')
+    // GET for nodes doesn't need params
+    const res = await GET()
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getNodes).toHaveBeenCalled()
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getNodes).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-nodes')
+    const res = await GET()
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-replicasets/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-replicasets/__tests__/route.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getReplicaSets: vi.fn()
+}))
+
+describe('API: k8s-replicasets', () => {
+  it('returns replicasets data on success', async () => {
+    const mockData = [{ 
+      name: 'test-rs', 
+      replicas: 3, 
+      ready: 3, 
+      available: 3,
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getReplicaSets).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-replicasets?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getReplicaSets).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getReplicaSets).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-replicasets')
+    await GET(req)
+    
+    expect(k8s.getReplicaSets).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getReplicaSets).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-replicasets?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-services/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-services/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getServices: vi.fn()
+}))
+
+describe('API: k8s-services', () => {
+  it('returns services data on success', async () => {
+    const mockData = [{ 
+      name: 'test-svc', 
+      type: 'ClusterIP',
+      clusterIP: '1.2.3.4',
+      ports: [],
+      selector: {},
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getServices).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-services?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getServices).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getServices).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-services')
+    await GET(req)
+    
+    expect(k8s.getServices).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getServices).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-services?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-statefulsets/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-statefulsets/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getStatefulSets: vi.fn()
+}))
+
+describe('API: k8s-statefulsets', () => {
+  it('returns statefulsets data on success', async () => {
+    const mockData = [{ 
+      name: 'test-sts', 
+      replicas: 3, 
+      ready: 3, 
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getStatefulSets).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-statefulsets?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getStatefulSets).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getStatefulSets).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-statefulsets')
+    await GET(req)
+    
+    expect(k8s.getStatefulSets).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getStatefulSets).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-statefulsets?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})

--- a/src/app/api/tools/k8s-volumes/__tests__/route.test.ts
+++ b/src/app/api/tools/k8s-volumes/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../route'
+import { NextRequest } from 'next/server'
+import * as k8s from '@/lib/k8s'
+
+// Mock the k8s library
+vi.mock('@/lib/k8s', () => ({
+  getPVCs: vi.fn()
+}))
+
+describe('API: k8s-volumes', () => {
+  it('returns PVC data on success', async () => {
+    const mockData = [{ 
+      name: 'test-pvc', 
+      status: 'Bound',
+      volume: 'test-vol',
+      capacity: '1Gi',
+      accessModes: 'RWO',
+      storageClass: 'standard',
+      created: '2023-01-01' 
+    }]
+    vi.mocked(k8s.getPVCs).mockResolvedValue(mockData as any)
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-volumes?namespace=default')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ data: mockData })
+    expect(k8s.getPVCs).toHaveBeenCalledWith('default')
+  })
+
+  it('uses default namespace if not provided', async () => {
+    vi.mocked(k8s.getPVCs).mockResolvedValue([])
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-volumes')
+    await GET(req)
+    
+    expect(k8s.getPVCs).toHaveBeenCalledWith('default')
+  })
+
+  it('returns 500 on error', async () => {
+    vi.mocked(k8s.getPVCs).mockRejectedValue(new Error('K8s error'))
+
+    const req = new NextRequest('http://localhost:3000/api/tools/k8s-volumes?namespace=test')
+    const res = await GET(req)
+    
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'K8s error' })
+  })
+})


### PR DESCRIPTION
Closes #36

This PR adds tests for the missing K8s API routes identified in issue #36.

## Changes
Added `__tests__/route.test.ts` for the following API routes:
- `src/app/api/tools/k8s-daemonsets`
- `src/app/api/tools/k8s-deployments`
- `src/app/api/tools/k8s-endpoints`
- `src/app/api/tools/k8s-events`
- `src/app/api/tools/k8s-ingresses`
- `src/app/api/tools/k8s-namespaces`
- `src/app/api/tools/k8s-nodes`
- `src/app/api/tools/k8s-replicasets`
- `src/app/api/tools/k8s-services`
- `src/app/api/tools/k8s-statefulsets`
- `src/app/api/tools/k8s-volumes`

## Acceptance Criteria Completion
- [x] Create `__tests__/route.test.ts` for each of the listed API routes.
- [x] Implement tests catering to `GET` requests, including successful data retrieval and error handling scenarios.
- [x] Ensure all new tests pass when running `npm test`.

All tests have been verified to pass locally.
