### PR TITLE
feat: implement RBAC resources (ServiceAccounts, Roles, RoleBindings)

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -25,7 +25,10 @@ test.describe('Dashboard Navigation', () => {
       'CronJobs',
       'Volumes (PVCs)',
       'Nodes',
-      'Events'
+      'Events',
+      'ServiceAccounts',
+      'Roles',
+      'RoleBindings'
     ];
 
     for (const item of sidebarItems) {

--- a/src/app/api/tools/k8s-rolebindings/route.ts
+++ b/src/app/api/tools/k8s-rolebindings/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRoleBindings } from "@/lib/k8s";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  let namespace = searchParams.get("namespace");
+  if (!namespace || !namespace.trim()) {
+    namespace = "default";
+  } else {
+    namespace = namespace.trim();
+  }
+
+  try {
+    const data = await getRoleBindings(namespace);
+    return NextResponse.json(data);
+  } catch (err: unknown) {
+    console.error("Error fetching role bindings:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch role bindings" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tools/k8s-roles/route.ts
+++ b/src/app/api/tools/k8s-roles/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRoles } from "@/lib/k8s";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  let namespace = searchParams.get("namespace");
+  if (!namespace || !namespace.trim()) {
+    namespace = "default";
+  } else {
+    namespace = namespace.trim();
+  }
+
+  try {
+    const data = await getRoles(namespace);
+    return NextResponse.json(data);
+  } catch (err: unknown) {
+    console.error("Error fetching roles:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch roles" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tools/k8s-serviceaccounts/route.ts
+++ b/src/app/api/tools/k8s-serviceaccounts/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceAccounts } from "@/lib/k8s";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  let namespace = searchParams.get("namespace");
+  if (!namespace || !namespace.trim()) {
+    namespace = "default";
+  } else {
+    namespace = namespace.trim();
+  }
+
+  try {
+    const data = await getServiceAccounts(namespace);
+    return NextResponse.json(data);
+  } catch (err: unknown) {
+    console.error("Error fetching service accounts:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch service accounts" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/k8s-dashboard/CommandPalette.tsx
+++ b/src/app/k8s-dashboard/CommandPalette.tsx
@@ -22,7 +22,8 @@ import {
   HardDrive, 
   Cpu,
   Clock,
-  Play
+  Play,
+  Lock
 } from "lucide-react";
 
 interface CommandPaletteProps {
@@ -52,6 +53,9 @@ const COMMANDS: {
   { cmd: "configmaps", alias: ["cm"], tool: "configmaps", label: "ConfigMaps", icon: <FileText className="w-4 h-4" /> },
   { cmd: "jobs", alias: ["job"], tool: "jobs", label: "Jobs", icon: <Play className="w-4 h-4" /> },
   { cmd: "cronjobs", alias: ["cj"], tool: "cronjobs", label: "CronJobs", icon: <Clock className="w-4 h-4" /> },
+  { cmd: "serviceaccounts", alias: ["sa"], tool: "serviceaccounts", label: "ServiceAccounts", icon: <Lock className="w-4 h-4" /> },
+  { cmd: "roles", alias: ["role"], tool: "roles", label: "Roles", icon: <Lock className="w-4 h-4" /> },
+  { cmd: "rolebindings", alias: ["rb"], tool: "rolebindings", label: "RoleBindings", icon: <Lock className="w-4 h-4" /> },
 ];
 
 export default function CommandPalette({ open, onOpenChange, onSelectTool }: CommandPaletteProps) {

--- a/src/app/k8s-dashboard/DashboardContent.tsx
+++ b/src/app/k8s-dashboard/DashboardContent.tsx
@@ -107,6 +107,9 @@ export default function DashboardContent({ namespace, tool }: DashboardContentPr
           "configmaps": "k8s-configmaps",
           "jobs": "k8s-jobs",
           "cronjobs": "k8s-cronjobs",
+          "serviceaccounts": "k8s-serviceaccounts",
+          "roles": "k8s-roles",
+          "rolebindings": "k8s-rolebindings",
         };
 
         const endpoint = endpointMap[tool];

--- a/src/app/k8s-dashboard/Sidebar.tsx
+++ b/src/app/k8s-dashboard/Sidebar.tsx
@@ -14,7 +14,8 @@ import {
   Cpu,
   FileText,
   Clock,
-  Play
+  Play,
+  Lock
 } from "lucide-react";
 import Image from "next/image";
 import {ModeToggle} from "@/components/ui/mode-toggle";
@@ -33,7 +34,10 @@ export type ToolType =
   | "nodes"
   | "configmaps"
   | "jobs"
-  | "cronjobs";
+  | "cronjobs"
+  | "serviceaccounts"
+  | "roles"
+  | "rolebindings";
 
 interface SidebarProps {
   namespaces: string[];
@@ -59,6 +63,9 @@ const TOOLS: { id: ToolType; label: string; icon: React.ReactNode }[] = [
   { id: "volumes", label: "Volumes (PVCs)", icon: <HardDrive className="w-4 h-4" /> },
   { id: "nodes", label: "Nodes", icon: <Cpu className="w-4 h-4" /> },
   { id: "events", label: "Events", icon: <Activity className="w-4 h-4" /> },
+  { id: "serviceaccounts", label: "ServiceAccounts", icon: <Lock className="w-4 h-4" /> },
+  { id: "roles", label: "Roles", icon: <Lock className="w-4 h-4" /> },
+  { id: "rolebindings", label: "RoleBindings", icon: <Lock className="w-4 h-4" /> },
 ];
 
 export default function Sidebar({

--- a/src/app/tools/k8s-rolebindings/page.tsx
+++ b/src/app/tools/k8s-rolebindings/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import useSWR from "swr";
+
+function fetcher(url: string) {
+  return fetch(url).then((res) => res.json());
+}
+
+interface RoleBinding {
+  name: string;
+  role: string;
+  subjects: string;
+  created: string;
+}
+
+function RoleBindingsTable({ data }: { data: RoleBinding[] }) {
+  return (
+    <div className="w-full overflow-x-auto">
+      <table className="min-w-full border border-zinc-200 dark:border-zinc-700">
+        <thead>
+          <tr className="bg-zinc-100 dark:bg-zinc-800">
+            <th className="px-4 py-2 text-left">Name</th>
+            <th className="px-4 py-2 text-left">Role Ref</th>
+            <th className="px-4 py-2 text-left">Subjects</th>
+            <th className="px-4 py-2 text-left">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-t border-zinc-200 dark:border-zinc-700">
+              <td className="px-4 py-2">{row.name}</td>
+              <td className="px-4 py-2">{row.role}</td>
+              <td className="px-4 py-2">{row.subjects || '-'}</td>
+              <td className="px-4 py-2">{row.created ? new Date(row.created).toLocaleDateString() : '-'}</td>
+            </tr>
+          ))}
+          {data.length === 0 && (
+            <tr>
+                <td colSpan={4} className="px-4 py-8 text-center text-zinc-500">No RoleBindings found</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RoleBindingsFetcher({ namespace }: { namespace: string }) {
+  const { data, error } = useSWR(`/api/tools/k8s-rolebindings?namespace=${namespace}`, fetcher, {
+    suspense: true,
+  });
+
+  if (error) return <div className="text-red-600">Error: {error.message}</div>;
+  if (!data) return <div>No data found.</div>;
+  
+  return <RoleBindingsTable data={Array.isArray(data) ? data : []} />;
+}
+
+function NamespaceSelect({ value, onChange }: { value: string, onChange: (val: string) => void }) {
+  const { data, error } = useSWR("/api/tools/k8s-namespaces", fetcher, {
+      suspense: true,
+      fallbackData: { namespaces: ["default"] }
+  });
+
+  if (error) return <div className="text-red-600 text-sm">Error loading namespaces</div>;
+
+  return (
+    <select
+      id="namespace"
+      className="border px-2 py-1 rounded w-48 dark:bg-zinc-800 dark:text-white"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {data?.namespaces?.map((ns: string) => (
+        <option key={ns} value={ns}>
+          {ns}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export default function K8sRoleBindingsPage() {
+  const [namespace, setNamespace] = useState("default");
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
+      <main className="flex w-full max-w-4xl flex-col gap-8 p-8 bg-white dark:bg-zinc-900 rounded-xl shadow-lg">
+        <h1 className="text-3xl font-bold mb-2 text-black dark:text-white">K8s RoleBindings</h1>
+        <form
+          className="flex gap-4 items-end"
+          onSubmit={e => {
+            e.preventDefault();
+          }}
+        >
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="namespace">Namespace</label>
+            <Suspense fallback={<div className="h-9 w-48 bg-gray-200 animate-pulse rounded dark:bg-zinc-800"></div>}>
+              <NamespaceSelect value={namespace} onChange={setNamespace} />
+            </Suspense>
+          </div>
+        </form>
+
+        <Suspense fallback={<div>Loading RoleBindings...</div>}>
+          <RoleBindingsFetcher namespace={namespace} key={namespace} />
+        </Suspense>
+      </main>
+    </div>
+  );
+}

--- a/src/app/tools/k8s-roles/page.tsx
+++ b/src/app/tools/k8s-roles/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import useSWR from "swr";
+
+function fetcher(url: string) {
+  return fetch(url).then((res) => res.json());
+}
+
+interface Role {
+  name: string;
+  rules: number;
+  created: string;
+}
+
+function RolesTable({ data }: { data: Role[] }) {
+  return (
+    <div className="w-full overflow-x-auto">
+      <table className="min-w-full border border-zinc-200 dark:border-zinc-700">
+        <thead>
+          <tr className="bg-zinc-100 dark:bg-zinc-800">
+            <th className="px-4 py-2 text-left">Name</th>
+            <th className="px-4 py-2 text-left">Rules Count</th>
+            <th className="px-4 py-2 text-left">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-t border-zinc-200 dark:border-zinc-700">
+              <td className="px-4 py-2">{row.name}</td>
+              <td className="px-4 py-2">{row.rules}</td>
+              <td className="px-4 py-2">{row.created ? new Date(row.created).toLocaleDateString() : '-'}</td>
+            </tr>
+          ))}
+          {data.length === 0 && (
+            <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-zinc-500">No Roles found</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RolesFetcher({ namespace }: { namespace: string }) {
+  const { data, error } = useSWR(`/api/tools/k8s-roles?namespace=${namespace}`, fetcher, {
+    suspense: true,
+  });
+
+  if (error) return <div className="text-red-600">Error: {error.message}</div>;
+  if (!data) return <div>No data found.</div>;
+  
+  return <RolesTable data={Array.isArray(data) ? data : []} />;
+}
+
+function NamespaceSelect({ value, onChange }: { value: string, onChange: (val: string) => void }) {
+  const { data, error } = useSWR("/api/tools/k8s-namespaces", fetcher, {
+      suspense: true,
+      fallbackData: { namespaces: ["default"] }
+  });
+
+  if (error) return <div className="text-red-600 text-sm">Error loading namespaces</div>;
+
+  return (
+    <select
+      id="namespace"
+      className="border px-2 py-1 rounded w-48 dark:bg-zinc-800 dark:text-white"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {data?.namespaces?.map((ns: string) => (
+        <option key={ns} value={ns}>
+          {ns}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export default function K8sRolesPage() {
+  const [namespace, setNamespace] = useState("default");
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
+      <main className="flex w-full max-w-4xl flex-col gap-8 p-8 bg-white dark:bg-zinc-900 rounded-xl shadow-lg">
+        <h1 className="text-3xl font-bold mb-2 text-black dark:text-white">K8s Roles</h1>
+        <form
+          className="flex gap-4 items-end"
+          onSubmit={e => {
+            e.preventDefault();
+          }}
+        >
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="namespace">Namespace</label>
+            <Suspense fallback={<div className="h-9 w-48 bg-gray-200 animate-pulse rounded dark:bg-zinc-800"></div>}>
+              <NamespaceSelect value={namespace} onChange={setNamespace} />
+            </Suspense>
+          </div>
+        </form>
+
+        <Suspense fallback={<div>Loading Roles...</div>}>
+          <RolesFetcher namespace={namespace} key={namespace} />
+        </Suspense>
+      </main>
+    </div>
+  );
+}

--- a/src/app/tools/k8s-serviceaccounts/page.tsx
+++ b/src/app/tools/k8s-serviceaccounts/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import useSWR from "swr";
+
+function fetcher(url: string) {
+  return fetch(url).then((res) => res.json());
+}
+
+interface ServiceAccount {
+  name: string;
+  secrets: string;
+  created: string;
+}
+
+function ServiceAccountsTable({ data }: { data: ServiceAccount[] }) {
+  return (
+    <div className="w-full overflow-x-auto">
+      <table className="min-w-full border border-zinc-200 dark:border-zinc-700">
+        <thead>
+          <tr className="bg-zinc-100 dark:bg-zinc-800">
+            <th className="px-4 py-2 text-left">Name</th>
+            <th className="px-4 py-2 text-left">Secrets</th>
+            <th className="px-4 py-2 text-left">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-t border-zinc-200 dark:border-zinc-700">
+              <td className="px-4 py-2">{row.name}</td>
+              <td className="px-4 py-2">{row.secrets || '-'}</td>
+              <td className="px-4 py-2">{row.created ? new Date(row.created).toLocaleDateString() : '-'}</td>
+            </tr>
+          ))}
+          {data.length === 0 && (
+            <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-zinc-500">No ServiceAccounts found</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ServiceAccountsFetcher({ namespace }: { namespace: string }) {
+  // Use namespace in specific key to refetch
+  const { data, error } = useSWR(`/api/tools/k8s-serviceaccounts?namespace=${namespace}`, fetcher, {
+    suspense: true,
+  });
+
+  if (error) return <div className="text-red-600">Error: {error.message}</div>;
+  if (!data) return <div>No data found.</div>;
+  
+  // The API returns the array directly, unlike ConfigMap which wraps in { data: [] } in previous log?
+  // Let me double check API route for ConfigMap.
+  // api/tools/k8s-configmaps used NextResponse.json({ data: configMaps }) -- wait, let me check k8s-configmaps/route.ts again.
+  return <ServiceAccountsTable data={Array.isArray(data) ? data : []} />;
+}
+
+function NamespaceSelect({ value, onChange }: { value: string, onChange: (val: string) => void }) {
+  const { data, error } = useSWR("/api/tools/k8s-namespaces", fetcher, {
+      suspense: true,
+      fallbackData: { namespaces: ["default"] }
+  });
+
+  if (error) return <div className="text-red-600 text-sm">Error loading namespaces</div>;
+
+  return (
+    <select
+      id="namespace"
+      className="border px-2 py-1 rounded w-48 dark:bg-zinc-800 dark:text-white"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {data?.namespaces?.map((ns: string) => (
+        <option key={ns} value={ns}>
+          {ns}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export default function K8sServiceAccountsPage() {
+  const [namespace, setNamespace] = useState("default");
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
+      <main className="flex w-full max-w-4xl flex-col gap-8 p-8 bg-white dark:bg-zinc-900 rounded-xl shadow-lg">
+        <h1 className="text-3xl font-bold mb-2 text-black dark:text-white">K8s ServiceAccounts</h1>
+        <form
+          className="flex gap-4 items-end"
+          onSubmit={e => {
+            e.preventDefault();
+            // Just submitting to trigger re-render if needed, but SWR handles it on prop change
+          }}
+        >
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="namespace">Namespace</label>
+            <Suspense fallback={<div className="h-9 w-48 bg-gray-200 animate-pulse rounded dark:bg-zinc-800"></div>}>
+              <NamespaceSelect value={namespace} onChange={setNamespace} />
+            </Suspense>
+          </div>
+        </form>
+
+        <Suspense fallback={<div>Loading ServiceAccounts...</div>}>
+          <ServiceAccountsFetcher namespace={namespace} key={namespace} />
+        </Suspense>
+      </main>
+    </div>
+  );
+}

--- a/src/lib/copilot-service.ts
+++ b/src/lib/copilot-service.ts
@@ -15,7 +15,10 @@ import {
   getNodes,
   getConfigMaps,
   getJobs,
-  getCronJobs
+  getCronJobs,
+  getServiceAccounts,
+  getRoles,
+  getRoleBindings
 } from "./k8s";
 
 // Define tools
@@ -180,6 +183,39 @@ const listCronJobsTool = defineTool("list_cronjobs", {
     }
 });
 
+const listServiceAccountsTool = defineTool("list_serviceaccounts", {
+    description: "List Kubernetes ServiceAccounts in a namespace",
+    parameters: z.object({
+        namespace: z.string().describe("Kubernetes namespace"),
+    }),
+    handler: async ({ namespace }) => {
+        const serviceAccounts = await getServiceAccounts(namespace);
+        return JSON.stringify(serviceAccounts);
+    }
+});
+
+const listRolesTool = defineTool("list_roles", {
+    description: "List Kubernetes Roles in a namespace",
+    parameters: z.object({
+        namespace: z.string().describe("Kubernetes namespace"),
+    }),
+    handler: async ({ namespace }) => {
+        const roles = await getRoles(namespace);
+        return JSON.stringify(roles);
+    }
+});
+
+const listRoleBindingsTool = defineTool("list_rolebindings", {
+    description: "List Kubernetes RoleBindings in a namespace",
+    parameters: z.object({
+        namespace: z.string().describe("Kubernetes namespace"),
+    }),
+    handler: async ({ namespace }) => {
+        const roleBindings = await getRoleBindings(namespace);
+        return JSON.stringify(roleBindings);
+    }
+});
+
 // Singleton client/session management
 // Note: In serverless environment, this might be re-initialized.
 // Ideally, for a robust app, we'd persist session state or use a persistent server.
@@ -232,7 +268,10 @@ export async function getSession(model: string = "gpt-4o") {
         listNodesTool,
         listConfigMapsTool,
         listJobsTool,
-        listCronJobsTool
+        listCronJobsTool,
+        listServiceAccountsTool,
+        listRolesTool,
+        listRoleBindingsTool
     ]
   });
   currentModel = model;

--- a/src/lib/k8s.ts
+++ b/src/lib/k8s.ts
@@ -17,7 +17,11 @@ import {
   V1PersistentVolumeClaim,
   V1Pod,
   V1Node,
-  V1ConfigMap
+  V1ConfigMap,
+  RbacAuthorizationV1Api,
+  V1ServiceAccount,
+  V1Role,
+  V1RoleBinding
 } from "@kubernetes/client-node";
 
 // Refactor to lazy-load clients to avoid top-level side effects (like connecting to cluster)
@@ -26,6 +30,7 @@ let k8sCoreApi: CoreV1Api | undefined;
 let k8sAppsApi: AppsV1Api | undefined;
 let k8sBatchApi: BatchV1Api | undefined;
 let k8sNetworkingApi: NetworkingV1Api | undefined;
+let k8sRbacApi: RbacAuthorizationV1Api | undefined;
 
 function getClients() {
   if (!k8sCoreApi) {
@@ -35,12 +40,14 @@ function getClients() {
     k8sAppsApi = kc.makeApiClient(AppsV1Api);
     k8sBatchApi = kc.makeApiClient(BatchV1Api);
     k8sNetworkingApi = kc.makeApiClient(NetworkingV1Api);
+    k8sRbacApi = kc.makeApiClient(RbacAuthorizationV1Api);
   }
   return {
     core: k8sCoreApi!,
     apps: k8sAppsApi!,
     batch: k8sBatchApi!,
     networking: k8sNetworkingApi!,
+    rbac: k8sRbacApi!,
   };
 }
 
@@ -250,6 +257,37 @@ export async function getCronJobs(namespace: string) {
     suspend: item.spec?.suspend,
     active: item.status?.active?.length || 0,
     lastScheduleTime: item.status?.lastScheduleTime,
+    created: item.metadata?.creationTimestamp,
+  }));
+}
+
+export async function getServiceAccounts(namespace: string) {
+  const { core } = getClients();
+  const resp = await core.listNamespacedServiceAccount({ namespace });
+  return resp.items.map((item: V1ServiceAccount) => ({
+    name: item.metadata?.name,
+    secrets: (item.secrets || []).map(s => s.name).join(', '),
+    created: item.metadata?.creationTimestamp,
+  }));
+}
+
+export async function getRoles(namespace: string) {
+  const { rbac } = getClients();
+  const resp = await rbac.listNamespacedRole({ namespace });
+  return resp.items.map((item: V1Role) => ({
+    name: item.metadata?.name,
+    rules: item.rules?.length || 0,
+    created: item.metadata?.creationTimestamp,
+  }));
+}
+
+export async function getRoleBindings(namespace: string) {
+  const { rbac } = getClients();
+  const resp = await rbac.listNamespacedRoleBinding({ namespace });
+  return resp.items.map((item: V1RoleBinding) => ({
+    name: item.metadata?.name,
+    role: item.roleRef.name,
+    subjects: (item.subjects || []).map(s => `${s.kind}/${s.name}`).join(', '),
     created: item.metadata?.creationTimestamp,
   }));
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17,7 +17,10 @@ import {
   getNodes,
   getConfigMaps,
   getJobs,
-  getCronJobs
+  getCronJobs,
+  getServiceAccounts,
+  getRoles,
+  getRoleBindings
 } from "./lib/k8s"; // Using relative path to ensure resolution without extra alias config if needed
 
 const server = new Server(
@@ -198,6 +201,45 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
+      {
+        name: "list_serviceaccounts",
+        description: "List Kubernetes ServiceAccounts in a namespace",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: {
+              type: "string",
+              description: "Kubernetes namespace (default: default)",
+            },
+          },
+        },
+      },
+      {
+        name: "list_roles",
+        description: "List Kubernetes Roles in a namespace",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: {
+              type: "string",
+              description: "Kubernetes namespace (default: default)",
+            },
+          },
+        },
+      },
+      {
+        name: "list_rolebindings",
+        description: "List Kubernetes RoleBindings in a namespace",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: {
+              type: "string",
+              description: "Kubernetes namespace (default: default)",
+            },
+          },
+        },
+      },
     ],
   };
 });
@@ -322,6 +364,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const data = await getCronJobs(namespace);
         return {
           content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        };
+      }
+
+      case "list_serviceaccounts": {
+        const namespace = getNamespace(args);
+        const serviceAccounts = await getServiceAccounts(namespace);
+        return {
+          content: [{ type: "text", text: JSON.stringify(serviceAccounts, null, 2) }],
+        };
+      }
+
+      case "list_roles": {
+        const namespace = getNamespace(args);
+        const roles = await getRoles(namespace);
+        return {
+          content: [{ type: "text", text: JSON.stringify(roles, null, 2) }],
+        };
+      }
+
+      case "list_rolebindings": {
+        const namespace = getNamespace(args);
+        const roleBindings = await getRoleBindings(namespace);
+        return {
+          content: [{ type: "text", text: JSON.stringify(roleBindings, null, 2) }],
         };
       }
 


### PR DESCRIPTION
Closes #13

## Description
This PR implements functionality to view RBAC resources: ServiceAccounts, Roles, and RoleBindings across all integration modes (Web UI, MCP, and Copilot).

## Changes
- **Library (`src/lib/k8s.ts`)**: Added `getServiceAccounts`, `getRoles`, and `getRoleBindings` using lazy-loaded `RbacAuthorizationV1Api`.
- **API Routes**: Added endpoints for:
    - `/api/tools/k8s-serviceaccounts`
    - `/api/tools/k8s-roles`
    - `/api/tools/k8s-rolebindings`
- **MCP Server**: Added tools `list_serviceaccounts`, `list_roles`, `list_rolebindings`.
- **Copilot**: Added corresponding tools to `copilot-service.ts`.
- **UI**: 
    - Added dedicated pages in `/tools/`.
    - Updated Dashboard Sidebar and Content to support new resources.
    - Updated Command Palette with shortcuts (`:sa`, `:role`, `:rb`).
- **Tests**: Updated E2E navigation tests.