### PR TITLE
fix: Add missing fallbackData to useSWR with suspense to fix prerender error

### DIFF
--- a/src/app/tools/k8s-rolebindings/page.tsx
+++ b/src/app/tools/k8s-rolebindings/page.tsx
@@ -49,6 +49,7 @@ function RoleBindingsTable({ data }: { data: RoleBinding[] }) {
 function RoleBindingsFetcher({ namespace }: { namespace: string }) {
   const { data, error } = useSWR(`/api/tools/k8s-rolebindings?namespace=${namespace}`, fetcher, {
     suspense: true,
+    fallbackData: [],
   });
 
   if (error) return <div className="text-red-600">Error: {error.message}</div>;

--- a/src/app/tools/k8s-roles/page.tsx
+++ b/src/app/tools/k8s-roles/page.tsx
@@ -46,6 +46,7 @@ function RolesTable({ data }: { data: Role[] }) {
 function RolesFetcher({ namespace }: { namespace: string }) {
   const { data, error } = useSWR(`/api/tools/k8s-roles?namespace=${namespace}`, fetcher, {
     suspense: true,
+    fallbackData: [],
   });
 
   if (error) return <div className="text-red-600">Error: {error.message}</div>;

--- a/src/app/tools/k8s-serviceaccounts/page.tsx
+++ b/src/app/tools/k8s-serviceaccounts/page.tsx
@@ -47,6 +47,7 @@ function ServiceAccountsFetcher({ namespace }: { namespace: string }) {
   // Use namespace in specific key to refetch
   const { data, error } = useSWR(`/api/tools/k8s-serviceaccounts?namespace=${namespace}`, fetcher, {
     suspense: true,
+    fallbackData: [],
   });
 
   if (error) return <div className="text-red-600">Error: {error.message}</div>;


### PR DESCRIPTION
This PR fixes a build error during prerendering: `Error: Fallback data is required when using Suspense in SSR`.

The fix involves adding `fallbackData: []` to `useSWR` hooks that have `suspense: true` enabled in the following pages:
- `src/app/tools/k8s-rolebindings/page.tsx`
- `src/app/tools/k8s-roles/page.tsx`
- `src/app/tools/k8s-serviceaccounts/page.tsx`

This ensures that Next.js has initial data during server-side rendering, preventing the suspense boundary from causing a failure during build time.