### PR TITLE
Enable CLI install and `st-k8s` launch command (fixes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The dashboard supports K9s-style keyboard navigation. Press `:` to open the comm
   - [Keyboard Navigation](#keyboard-navigation)
   - [Table of Contents](#table-of-contents)
   - [How to Run](#how-to-run)
+    - [Using the `st-k8s` CLI](#using-the-st-k8s-cli)
     - [Running Tests](#running-tests)
     - [End-to-End Tests](#end-to-end-tests)
   - [API](#api)
@@ -53,6 +54,26 @@ git clone https://github.com/bhf/st-k8s
 npm run build
 npm run start
 ```
+
+### Using the `st-k8s` CLI
+
+You can install the project as a global CLI to run the app using the `st-k8s` command.
+
+```bash
+# From the repo root — install globally (or publish and install from a registry)
+npm install -g .
+
+# During development, link the local package to make `st-k8s` available globally
+npm link
+
+# Then launch the app with the CLI (it will build if no build exists)
+st-k8s
+```
+
+Notes:
+- `npm install -g .` requires appropriate permissions (use `sudo` on some systems).
+- `npm link` is useful when iterating locally — run it once from the repo root.
+- The `st-k8s` command will attempt to use a Next.js standalone server if present (from `next build`), otherwise it runs `npm run start`.
 
 ### Running Tests
 

--- a/bin/st-k8s
+++ b/bin/st-k8s
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const { existsSync } = require('fs');
+const path = require('path');
+
+function printBanner() {
+  const banner = [
+    ' /\/|_    _____ _            _____                    _          ',
+    '|/\/| |  /  ___| |          |_   _|                  | |         ',
+    '   / __) \\ `--.| |_ __ _ _   _| |_   _ _ __   ___  __| |         ',
+    "   \\__ \\  `--. \\ __/ _` | | | | | | | | '_ \ / _ \/ _` |         ",
+    "   (   / /\\__/ / || (_| | |_| | | |_| | | | |  __/ (_| |         ",
+    "    |_|  \\____/ \\__\\__,_|\\__, \\_/\\__,_|_| |_|\\___|\\__,_|         ",
+    "                          __/ |                           ______ ",
+    "                         |___/                           |______|",
+    '',
+    '  GitHub: https://github.com/bhf',
+    ''
+  ].join('\n');
+
+  console.log(banner);
+}
+
+function run(cmd, args) {
+  const res = spawnSync(cmd, args, { stdio: 'inherit' });
+  if (res.error) {
+    console.error(res.error);
+    process.exit(1);
+  }
+  if (res.status !== 0) process.exit(res.status || 1);
+}
+
+const root = process.cwd();
+const standaloneServer = path.join(root, '.next', 'standalone', 'server.js');
+
+// Print banner on launch
+printBanner();
+
+// Build if needed
+if (!existsSync(path.join(root, '.next'))) {
+  console.log('No build detected — running `npm run build`...');
+  run('npm', ['run', 'build']);
+}
+
+// Prefer standalone server if present
+if (existsSync(standaloneServer)) {
+  console.log('Starting standalone server...');
+  run('node', [standaloneServer]);
+} else {
+  console.log('Starting Next.js production server (`npm run start`)...');
+  run('npm', ['run', 'start']);
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "st-k8s",
   "version": "0.1.0",
   "private": true,
+  "bin": {
+    "st-k8s": "bin/st-k8s"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Adds a global CLI entry `st-k8s` and a `bin/st-k8s` launcher script that builds (if needed) and starts the Next.js app. Also documents global install and `npm link` usage in the README.

Changes:
- `package.json`: added `bin` entry for `st-k8s`
- `bin/st-k8s`: executable launcher printing a banner and starting the app
- `README.md`: instructions for `npm install -g .`, `npm link`, and `st-k8s` usage

Fixes #66