### PR TITLE
ui: remove Workloads & Network heading from dashboard sidebar (#78)

### DIFF
--- a/src/app/k8s-dashboard/Sidebar.tsx
+++ b/src/app/k8s-dashboard/Sidebar.tsx
@@ -151,9 +151,6 @@ export default function Sidebar({
 
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-1">
-          <label className="text-sm font-medium text-zinc-500 dark:text-zinc-400 px-2 mb-2 block">
-            Workloads & Network
-          </label>
           {TOOLS.map((tool) => (
             <Button
               key={tool.id}


### PR DESCRIPTION
Resolves #78

### Description
This PR removes the "Workloads & Network" heading from the dashboard sidebar to simplify the UI and reduce visual clutter.

### Changes
- Deleted the `<label>` element containing "Workloads & Network" in `src/app/k8s-dashboard/Sidebar.tsx`.
- Navigation buttons remain functional and correctly spaced within their container.

### Testing
- Verified sidebar layout manually.
- Ran existing dashboard tests: `npm test -- src/app/k8s-dashboard/__tests__`.