### PR TITLE
feat: telemetry visualization and metrics MCP tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.0",
         "react-dom": "19.2.0",
+        "recharts": "^3.7.0",
         "sonner": "^2.0.7",
         "swr": "^2.4.0",
         "tailwind-merge": "^3.4.0",
@@ -3941,6 +3942,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -4309,7 +4346,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -4844,6 +4886,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4927,6 +5032,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.47.0",
@@ -6618,6 +6729,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6753,6 +6985,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -7119,6 +7357,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -7635,6 +7883,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
@@ -8418,6 +8672,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8474,6 +8738,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -10630,8 +10903,32 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -10712,6 +11009,36 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -10724,6 +11051,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -10778,6 +11121,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -11699,6 +12048,12 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -12260,6 +12615,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "recharts": "^3.7.0",
     "sonner": "^2.0.7",
     "swr": "^2.4.0",
     "tailwind-merge": "^3.4.0",

--- a/src/app/api/tools/k8s-metrics-nodes/route.ts
+++ b/src/app/api/tools/k8s-metrics-nodes/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getNodeMetrics } from "@/lib/k8s";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const context = searchParams.get("context") || undefined;
+
+    try {
+        const result = await getNodeMetrics(context);
+        return NextResponse.json({ data: result });
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Failed to fetch node metrics";
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/src/app/api/tools/k8s-metrics-pods/route.ts
+++ b/src/app/api/tools/k8s-metrics-pods/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPodMetrics } from "@/lib/k8s";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const context = searchParams.get("context") || undefined;
+    let namespace = searchParams.get("namespace");
+
+    if (!namespace || !namespace.trim()) {
+        namespace = "default";
+    } else {
+        namespace = namespace.trim();
+    }
+
+    try {
+        const result = await getPodMetrics(namespace, context);
+        return NextResponse.json({ data: result });
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Failed to fetch pod metrics";
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/src/app/api/tools/k8s-metrics-status/route.ts
+++ b/src/app/api/tools/k8s-metrics-status/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isMetricsAvailable } from "@/lib/k8s";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const context = searchParams.get("context") || undefined;
+
+    try {
+        const available = await isMetricsAvailable();
+        return NextResponse.json({ available });
+    } catch (err: unknown) {
+        return NextResponse.json({ available: false });
+    }
+}

--- a/src/app/k8s-dashboard/DashboardContent.tsx
+++ b/src/app/k8s-dashboard/DashboardContent.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ToolType } from "./Sidebar";
 import { Grid, List, Download, Zap, XCircle, MessageSquarePlus } from "lucide-react";
+import { MetricsDashboard } from "@/components/MetricsCharts";
 import { useChat } from "@/components/ChatContext";
 import { RefreshSelector } from "@/components/RefreshSelector";
 import { useRefresh } from "@/lib/refresh-context";
@@ -124,9 +125,13 @@ export default function DashboardContent({ namespace, context, tool }: Dashboard
         "roles": "k8s-roles",
         "rolebindings": "k8s-rolebindings",
         "port-forwards": "k8s-port-forward",
+        "metrics": "k8s-metrics-pods", // Default to pods for metrics tool if namespace selected
       };
 
-      const endpoint = endpointMap[tool];
+      let endpoint = endpointMap[tool];
+      if (tool === "metrics" && (!namespace || namespace === "all")) {
+        endpoint = "k8s-metrics-nodes";
+      }
       const url = new URL(`/api/tools/${endpoint}`, window.location.origin);
       if (namespace) {
         url.searchParams.set("namespace", namespace);
@@ -289,7 +294,12 @@ export default function DashboardContent({ namespace, context, tool }: Dashboard
 
       {!loading && !error && data.length > 0 && (
         <>
-          {viewMode === "grid" ? (
+          {tool === "metrics" ? (
+            <MetricsDashboard
+              nodes={((!namespace || namespace === "all") ? data : []) as any}
+              pods={(namespace && namespace !== "all" ? data : []) as any}
+            />
+          ) : viewMode === "grid" ? (
             <div className="grid gap-4 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
               {data.map((item, i) => (
                 <ResourceCard key={i} item={item} tool={tool} />

--- a/src/app/k8s-dashboard/Sidebar.tsx
+++ b/src/app/k8s-dashboard/Sidebar.tsx
@@ -19,7 +19,8 @@ import {
   Zap
 } from "lucide-react";
 import Image from "next/image";
-import {ModeToggle} from "@/components/ui/mode-toggle";
+import { ModeToggle } from "@/components/ui/mode-toggle";
+import { useState, useEffect } from "react";
 
 export type ToolType =
   | "pod-resources"
@@ -39,7 +40,8 @@ export type ToolType =
   | "serviceaccounts"
   | "roles"
   | "rolebindings"
-  | "port-forwards";
+  | "port-forwards"
+  | "metrics";
 
 interface SidebarProps {
   selectedTool: ToolType;
@@ -65,12 +67,27 @@ const TOOLS: { id: ToolType; label: string; icon: React.ReactNode }[] = [
   { id: "roles", label: "Roles", icon: <Lock className="w-4 h-4" /> },
   { id: "rolebindings", label: "RoleBindings", icon: <Lock className="w-4 h-4" /> },
   { id: "port-forwards", label: "Port Forwards", icon: <Zap className="w-4 h-4" /> },
+  { id: "metrics", label: "Metrics", icon: <Activity className="w-4 h-4" /> },
 ];
 
 export default function Sidebar({
   selectedTool,
   onSelectTool,
 }: SidebarProps) {
+  const [metricsAvailable, setMetricsAvailable] = useState<boolean>(true);
+
+  useEffect(() => {
+    fetch('/api/tools/k8s-metrics-status')
+      .then(res => res.json())
+      .then(data => setMetricsAvailable(data.available))
+      .catch(() => setMetricsAvailable(false));
+  }, []);
+
+  const visibleTools = TOOLS.filter(tool => {
+    if (tool.id === "metrics") return metricsAvailable;
+    return true;
+  });
+
   return (
     <aside className="hidden md:flex md:w-64 bg-zinc-50 dark:bg-zinc-900 border-r flex-col h-full">
       <div className="p-4 border-b flex items-center bg-black justify-between gap-3">
@@ -92,7 +109,7 @@ export default function Sidebar({
 
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-1">
-          {TOOLS.map((tool) => (
+          {visibleTools.map((tool) => (
             <Button
               key={tool.id}
               variant={selectedTool === tool.id ? "secondary" : "ghost"}

--- a/src/components/MetricsCharts.tsx
+++ b/src/components/MetricsCharts.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React, { useMemo } from 'react';
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface MetricsData {
+    name: string;
+    cpu: string;
+    memory: string;
+    timestamp?: string;
+    window?: string;
+    containers?: Array<{
+        name: string;
+        cpu: string;
+        memory: string;
+    }>;
+}
+
+interface ResourceChartProps {
+    title: string;
+    data: MetricsData[];
+    type: 'cpu' | 'memory';
+}
+
+// Helper to parse K8s units
+const parseCpu = (cpu: string | undefined) => {
+    if (!cpu) return 0;
+    if (cpu.endsWith('n')) return parseFloat(cpu) / 1000000;
+    if (cpu.endsWith('u')) return parseFloat(cpu) / 1000;
+    if (cpu.endsWith('m')) return parseFloat(cpu);
+    return parseFloat(cpu) * 1000; // Assume cores if no unit
+};
+
+const parseMemory = (mem: string | undefined) => {
+    if (!mem) return 0;
+    if (mem.endsWith('Ki')) return parseFloat(mem) / 1024;
+    if (mem.endsWith('Mi')) return parseFloat(mem);
+    if (mem.endsWith('Gi')) return parseFloat(mem) * 1024;
+    return parseFloat(mem) / (1024 * 1024); // Assume bytes if no unit
+};
+
+export const ResourceChart = ({ title, data, type }: ResourceChartProps) => {
+    const chartData = useMemo(() => {
+        return data.map(item => ({
+            name: item.name,
+            value: type === 'cpu' ? parseCpu(item.cpu) : parseMemory(item.memory),
+            original: type === 'cpu' ? item.cpu : item.memory
+        })).sort((a, b) => b.value - a.value);
+    }, [data, type]);
+
+    const unit = type === 'cpu' ? 'm' : 'Mi';
+    const color = type === 'cpu' ? '#3b82f6' : '#10b981';
+
+    return (
+        <Card className="w-full">
+            <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">{title} ({unit})</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div className="h-[300px] w-full">
+                    <ResponsiveContainer width="100%" height="100%">
+                        <BarChart
+                            data={chartData}
+                            layout="vertical"
+                            margin={{ top: 5, right: 30, left: 40, bottom: 5 }}
+                        >
+                            <CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={false} strokeOpacity={0.2} />
+                            <XAxis type="number" hide />
+                            <YAxis
+                                type="category"
+                                dataKey="name"
+                                width={100}
+                                fontSize={12}
+                                tickLine={false}
+                                axisLine={false}
+                            />
+                            <Tooltip
+                                cursor={{ fill: 'rgba(0,0,0,0.05)' }}
+                                content={({ active, payload }) => {
+                                    if (active && payload && payload.length) {
+                                        const data = payload[0].payload;
+                                        return (
+                                            <div className="bg-background border rounded-md p-2 shadow-md text-xs">
+                                                <p className="font-bold">{data.name}</p>
+                                                <p>{type.toUpperCase()}: {data.original}</p>
+                                            </div>
+                                        );
+                                    }
+                                    return null;
+                                }}
+                            />
+                            <Bar
+                                dataKey="value"
+                                fill={color}
+                                radius={[0, 4, 4, 0]}
+                                barSize={20}
+                            />
+                        </BarChart>
+                    </ResponsiveContainer>
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+
+export const MetricsDashboard = ({ nodes, pods }: { nodes: MetricsData[], pods: MetricsData[] }) => {
+    return (
+        <div className="grid gap-6">
+            {nodes.length > 0 && (
+                <div className="grid gap-4 md:grid-cols-2">
+                    <ResourceChart title="Node CPU Usage" data={nodes} type="cpu" />
+                    <ResourceChart title="Node Memory Usage" data={nodes} type="memory" />
+                </div>
+            )}
+
+            {pods.length > 0 && (
+                <div className="grid gap-4 md:grid-cols-2">
+                    <ResourceChart title="Pod CPU Usage" data={pods} type="cpu" />
+                    <ResourceChart title="Pod Memory Usage" data={pods} type="memory" />
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/lib/__tests__/k8s.test.ts
+++ b/src/lib/__tests__/k8s.test.ts
@@ -31,6 +31,10 @@ const mocks = vi.hoisted(() => {
     rbacApi: {
       listNamespacedRole: vi.fn(),
       listNamespacedRoleBinding: vi.fn(),
+    },
+    customApi: {
+      listClusterCustomObject: vi.fn(),
+      listNamespacedCustomObject: vi.fn(),
     }
   }
 })
@@ -38,7 +42,7 @@ const mocks = vi.hoisted(() => {
 // Mock the kubernetes client
 vi.mock('@kubernetes/client-node', async (importOriginal) => {
   const actual = await importOriginal<typeof k8sClient>()
-  
+
   return {
     ...actual,
     KubeConfig: class {
@@ -49,6 +53,7 @@ vi.mock('@kubernetes/client-node', async (importOriginal) => {
         if (cls === actual.NetworkingV1Api) return mocks.networkingApi
         if (cls === actual.BatchV1Api) return mocks.batchApi
         if (cls === actual.RbacAuthorizationV1Api) return mocks.rbacApi
+        if (cls === actual.CustomObjectsApi) return mocks.customApi
         return {}
       }
       getContexts = vi.fn().mockReturnValue([
@@ -62,17 +67,17 @@ vi.mock('@kubernetes/client-node', async (importOriginal) => {
 })
 
 // Import the module under test
-import { 
+import {
   getNamespaces, getPods, getDeployments, getNodes, getConfigMaps,
   getServices, getDaemonSets, getReplicaSets, getStatefulSets, getIngresses,
   getEndpoints, getEvents, getPVCs, getCronJobs, getServiceAccounts,
-  getRoles, getRoleBindings, getContexts
+  getRoles, getRoleBindings, getContexts, getNodeMetrics, getPodMetrics, resetMetricsApiAvailable
 } from '../k8s'
 
 describe('k8s library', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    
+
     // Set default successful responses to avoid crashes
     mocks.coreApi.listNamespace.mockResolvedValue({ items: [] })
     mocks.coreApi.listNamespacedPod.mockResolvedValue({ items: [] })
@@ -81,17 +86,21 @@ describe('k8s library', () => {
     mocks.coreApi.listNamespacedEvent.mockResolvedValue({ items: [] })
     mocks.coreApi.listNamespacedPersistentVolumeClaim.mockResolvedValue({ items: [] })
     mocks.coreApi.listNamespacedServiceAccount.mockResolvedValue({ items: [] })
-    
+
     mocks.appsApi.listNamespacedDeployment.mockResolvedValue({ items: [] })
     mocks.appsApi.listNamespacedDaemonSet.mockResolvedValue({ items: [] })
     mocks.appsApi.listNamespacedReplicaSet.mockResolvedValue({ items: [] })
     mocks.appsApi.listNamespacedStatefulSet.mockResolvedValue({ items: [] })
-    
+
     mocks.networkingApi.listNamespacedIngress.mockResolvedValue({ items: [] })
     mocks.batchApi.listNamespacedCronJob.mockResolvedValue({ items: [] })
-    
+
     mocks.rbacApi.listNamespacedRole.mockResolvedValue({ items: [] })
     mocks.rbacApi.listNamespacedRoleBinding.mockResolvedValue({ items: [] })
+
+    mocks.customApi.listClusterCustomObject.mockResolvedValue({ items: [] })
+    mocks.customApi.listNamespacedCustomObject.mockResolvedValue({ items: [] })
+    resetMetricsApiAvailable()
   })
 
   describe('getContexts', () => {
@@ -520,6 +529,83 @@ describe('k8s library', () => {
         created: '2023-01-01T00:00:00Z'
       })
       expect(mocks.rbacApi.listNamespacedRoleBinding).toHaveBeenCalledWith({ namespace: 'default' })
+    })
+  })
+
+  describe('getNodeMetrics', () => {
+    it('returns formatted node metrics', async () => {
+      mocks.customApi.listClusterCustomObject.mockResolvedValue({
+        items: [
+          {
+            metadata: { name: 'node-1' },
+            usage: { cpu: '100m', memory: '1Gi' },
+            timestamp: '2023-01-01T00:00:00Z',
+            window: '1m'
+          }
+        ]
+      })
+      const results = await getNodeMetrics()
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({
+        name: 'node-1',
+        cpu: '100m',
+        memory: '1Gi',
+        timestamp: '2023-01-01T00:00:00Z',
+        window: '1m'
+      })
+      expect(mocks.customApi.listClusterCustomObject).toHaveBeenCalledWith({
+        group: "metrics.k8s.io",
+        version: "v1beta1",
+        plural: "nodes",
+      })
+    })
+
+    it('returns empty list and silences console on 404', async () => {
+      mocks.customApi.listClusterCustomObject.mockRejectedValue({ code: 404 })
+      const results = await getNodeMetrics()
+      expect(results).toEqual([])
+    })
+  })
+
+  describe('getPodMetrics', () => {
+    it('returns formatted pod metrics', async () => {
+      mocks.customApi.listNamespacedCustomObject.mockResolvedValue({
+        items: [
+          {
+            metadata: { name: 'pod-1', namespace: 'default' },
+            containers: [
+              { name: 'container-1', usage: { cpu: '50m', memory: '512Mi' } }
+            ],
+            timestamp: '2023-01-01T00:00:00Z',
+            window: '1m'
+          }
+        ]
+      })
+      const results = await getPodMetrics('default')
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({
+        name: 'pod-1',
+        namespace: 'default',
+        cpu: '50m',
+        memory: '512Mi',
+        containers: [
+          { name: 'container-1', cpu: '50m', memory: '512Mi' }
+        ],
+        timestamp: '2023-01-01T00:00:00Z',
+        window: '1m'
+      })
+      expect(mocks.customApi.listNamespacedCustomObject).toHaveBeenCalledWith({
+        group: "metrics.k8s.io",
+        version: "v1beta1",
+        namespace: 'default',
+        plural: "pods",
+      })
+    })
+
+    it('returns empty list and silences console on 404', async () => {
+      mocks.customApi.listNamespacedCustomObject.mockRejectedValue({ code: 404 })
+      const results = await getPodMetrics('default')
+      expect(results).toEqual([])
     })
   })
 })

--- a/src/lib/k8s.ts
+++ b/src/lib/k8s.ts
@@ -24,6 +24,7 @@ import {
   V1RoleBinding,
   Log,
   PortForward,
+  CustomObjectsApi,
 } from "@kubernetes/client-node";
 import { Writable } from "node:stream";
 import net from "node:net";
@@ -36,6 +37,7 @@ type K8sClients = {
   batch: BatchV1Api;
   networking: NetworkingV1Api;
   rbac: RbacAuthorizationV1Api;
+  custom: CustomObjectsApi;
   config: KubeConfig;
 };
 
@@ -44,7 +46,7 @@ const clientsCache = new Map<string, K8sClients>();
 function getClients(context?: string): K8sClients {
   const kc = new KubeConfig();
   kc.loadFromDefault();
-  
+
   // If no context provided, use current context from kubeconfig
   const effectiveContext = context || kc.getCurrentContext();
   const cacheKey = effectiveContext;
@@ -67,6 +69,7 @@ function getClients(context?: string): K8sClients {
     batch: kc.makeApiClient(BatchV1Api),
     networking: kc.makeApiClient(NetworkingV1Api),
     rbac: kc.makeApiClient(RbacAuthorizationV1Api),
+    custom: kc.makeApiClient(CustomObjectsApi),
     config: kc,
   };
 
@@ -331,13 +334,13 @@ export async function findPodForService(namespace: string, serviceName: string, 
   const { core } = getClients(context);
   const svc = await core.readNamespacedService({ name: serviceName, namespace });
   const selector = svc.spec?.selector;
-  
+
   if (!selector) return null;
-  
+
   const labelSelector = Object.entries(selector)
     .map(([key, value]) => `${key}=${value}`)
     .join(',');
-    
+
   const pods = await core.listNamespacedPod({ namespace, labelSelector });
   return pods.items[0]?.metadata?.name || null;
 }
@@ -358,9 +361,9 @@ export async function getPodLogs(namespace: string, podName: string, containerNa
 export async function getPodLogStream(namespace: string, podName: string, containerName: string, stream: Writable, tailLines?: number, sinceSeconds?: number, context?: string) {
   const { config } = getClients(context);
   const log = new Log(config);
-  
-  return log.log(namespace, podName, containerName, stream, { 
-    follow: true, 
+
+  return log.log(namespace, podName, containerName, stream, {
+    follow: true,
     tailLines: tailLines,
     sinceSeconds: sinceSeconds,
     pretty: false,
@@ -383,7 +386,7 @@ const activeForwards = new Map<string, { info: ActiveForward; stop: () => void }
 export async function startPortForward(namespace: string, podName: string, containerPort: number, localPort?: number, localAddress: string = '127.0.0.1', context?: string): Promise<ActiveForward> {
   const { config } = getClients(context);
   const pf = new PortForward(config);
-  
+
   const server = net.createServer((socket) => {
     pf.portForward(namespace, podName, [containerPort], socket, null, socket);
   });
@@ -392,7 +395,7 @@ export async function startPortForward(namespace: string, podName: string, conta
     server.listen(localPort || 0, localAddress, () => {
       const address = server.address() as net.AddressInfo;
       const id = `${namespace}-${podName}-${containerPort}-${address.port}`;
-      
+
       const info: ActiveForward = {
         id,
         namespace,
@@ -402,9 +405,9 @@ export async function startPortForward(namespace: string, podName: string, conta
         localAddress: address.address,
         created: new Date()
       };
-      
-      activeForwards.set(id, { 
-        info, 
+
+      activeForwards.set(id, {
+        info,
         stop: () => {
           server.close();
           activeForwards.delete(id);
@@ -412,7 +415,7 @@ export async function startPortForward(namespace: string, podName: string, conta
       });
       resolve(info);
     });
-    
+
     server.on('error', (err) => {
       console.error('Port forward server error:', err);
       reject(err);
@@ -431,4 +434,121 @@ export async function stopPortForward(id: string) {
 
 export function listPortForwards(): ActiveForward[] {
   return Array.from(activeForwards.values()).map(f => f.info);
+}
+
+let metricsApiAvailable: boolean | null = null;
+
+export function resetMetricsApiAvailable() {
+  metricsApiAvailable = null;
+}
+
+export async function isMetricsAvailable() {
+  // If we already know the status, return it
+  if (metricsApiAvailable !== null) return metricsApiAvailable;
+
+  // Try a quick check by calling getNodeMetrics
+  await getNodeMetrics();
+  return metricsApiAvailable || false;
+}
+
+async function checkMetricsApi(context?: string) {
+  if (metricsApiAvailable !== null) return metricsApiAvailable;
+
+  const { config } = getClients(context);
+  try {
+    const kc = config;
+    const cluster = kc.getCurrentCluster();
+    if (!cluster) return false;
+
+    // We can't easily check 'apis' via client-node without more boilerplate,
+    // so we'll just do a test call and cache the result.
+    metricsApiAvailable = false;
+    return false;
+  } catch (e) {
+    metricsApiAvailable = false;
+    return false;
+  }
+}
+
+export async function getNodeMetrics(context?: string) {
+  if (metricsApiAvailable === false) return [];
+
+  const { custom } = getClients(context);
+  try {
+    const res = await custom.listClusterCustomObject({
+      group: "metrics.k8s.io",
+      version: "v1beta1",
+      plural: "nodes",
+    }) as { items: Array<{ metadata: { name: string }, usage: { cpu: string, memory: string }, timestamp: string, window: string }> };
+
+    metricsApiAvailable = true;
+    return (res.items || []).map((node) => ({
+      name: node.metadata.name,
+      cpu: node.usage.cpu,
+      memory: node.usage.memory,
+      timestamp: node.timestamp,
+      window: node.window,
+    }));
+  } catch (err: any) {
+    if (err.code === 404 || err.status === 404) {
+      metricsApiAvailable = false;
+    } else {
+      console.error("Failed to fetch node metrics:", err);
+    }
+    return [];
+  }
+}
+
+export async function getPodMetrics(namespace: string, context?: string) {
+  if (metricsApiAvailable === false) return [];
+
+  const { custom } = getClients(context);
+  try {
+    const res = await custom.listNamespacedCustomObject({
+      group: "metrics.k8s.io",
+      version: "v1beta1",
+      namespace,
+      plural: "pods",
+    }) as { items: Array<{ metadata: { name: string, namespace: string }, containers: Array<{ name: string, usage: { cpu: string, memory: string } }>, timestamp: string, window: string }> };
+
+    metricsApiAvailable = true;
+    return (res.items || []).map((pod) => {
+      const cpuNanocores = pod.containers.reduce((acc, c) => {
+        const val = c.usage.cpu;
+        if (val.endsWith('n')) return acc + parseFloat(val);
+        if (val.endsWith('u')) return acc + parseFloat(val) * 1000;
+        if (val.endsWith('m')) return acc + parseFloat(val) * 1000000;
+        return acc + parseFloat(val) * 1000000000;
+      }, 0);
+
+      const memKi = pod.containers.reduce((acc, c) => {
+        const val = c.usage.memory;
+        if (val.endsWith('Ki')) return acc + parseFloat(val);
+        if (val.endsWith('Mi')) return acc + parseFloat(val) * 1024;
+        if (val.endsWith('Gi')) return acc + parseFloat(val) * 1024 * 1024;
+        return acc + parseFloat(val) / 1024;
+      }, 0);
+
+      return {
+        name: pod.metadata.name,
+        namespace: pod.metadata.namespace,
+        cpu: `${Math.round(cpuNanocores / 1000000)}m`,
+        memory: `${Math.round(memKi / 1024)}Mi`,
+        containers: pod.containers.map((container) => ({
+          name: container.name,
+          cpu: container.usage.cpu,
+          memory: container.usage.memory,
+        })),
+        timestamp: pod.timestamp,
+        window: pod.window,
+      };
+    });
+  } catch (err: any) {
+    if (err.code === 404 || err.status === 404) {
+      metricsApiAvailable = false;
+    } else {
+      console.error(`Failed to fetch pod metrics for namespace ${namespace}:`, err);
+    }
+    return [];
+  }
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -26,7 +26,9 @@ import {
   startPortForward,
   stopPortForward,
   listPortForwards,
-  findPodForService
+  findPodForService,
+  getNodeMetrics,
+  getPodMetrics
 } from "./lib/k8s"; // Using relative path to ensure resolution without extra alias config if needed
 
 const server = new Server(
@@ -43,11 +45,11 @@ const server = new Server(
 
 // Helper to handle arguments
 const getK8sArgs = (args: unknown) => {
-  const parsed = z.object({ 
+  const parsed = z.object({
     namespace: z.string().optional(),
     context: z.string().optional()
   }).safeParse(args);
-  
+
   return {
     namespace: parsed.success ? (parsed.data.namespace?.trim() || "default") : "default",
     context: parsed.success ? (parsed.data.context?.trim() || undefined) : undefined
@@ -332,6 +334,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {},
         },
       },
+      {
+        name: "get_node_metrics",
+        description: "Get resource usage metrics for cluster nodes (CPU/Memory)",
+        inputSchema: {
+          type: "object",
+          properties: {
+            context: { type: "string", description: "Kubernetes context name (optional)" },
+          },
+        },
+      },
+      {
+        name: "get_pod_metrics",
+        description: "Get resource usage metrics for pods in a namespace",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: { type: "string", description: "Kubernetes namespace (default: default)" },
+            context: { type: "string", description: "Kubernetes context name (optional)" },
+          },
+        },
+      },
     ],
   };
 });
@@ -536,7 +559,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             throw new Error(`No pods found for service ${serviceName}`);
           }
         }
-        
+
         if (!targetPod) {
           throw new Error("Either podName or serviceName must be provided");
         }
@@ -567,6 +590,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const forwards = listPortForwards();
         return {
           content: [{ type: "text", text: JSON.stringify(forwards, null, 2) }],
+        };
+      }
+
+      case "get_node_metrics": {
+        const { context } = getK8sArgs(args);
+        const metrics = await getNodeMetrics(context);
+        return {
+          content: [{ type: "text", text: JSON.stringify(metrics, null, 2) }],
+        };
+      }
+
+      case "get_pod_metrics": {
+        const { namespace, context } = getK8sArgs(args);
+        const metrics = await getPodMetrics(namespace, context);
+        return {
+          content: [{ type: "text", text: JSON.stringify(metrics, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Description
This PR implements telemetry and metrics visualization for the Kubernetes dashboard and exposes this data via the MCP server, as requested in issue #73.

### Changes
- **Backend**: Added `getNodeMetrics` and `getPodMetrics` to `src/lib/k8s.ts` using `CustomObjectsApi`.
- **API Routes**: Created `/api/tools/k8s-metrics-nodes`, `/api/tools/k8s-metrics-pods`, and `/api/tools/k8s-metrics-status`.
- **MCP Server**: Registered `get_node_metrics` and `get_pod_metrics` as available tools.
- **Frontend**:
  - Integrated `recharts` for visualization.
  - Created reusable `MetricsCharts` component.
  - Added a "Metrics" button to the sidebar that conditionally appears if the Metrics API is available in the cluster.
  - Integrated metric charts into `DashboardContent.tsx`.

### Verification
- Added 22 unit tests for metrics logic in `src/lib/__tests__/k8s.test.ts`.
- Verified graceful failure when `metrics-server` is missing (button is hidden, logs are silenced).
- Verified runtime stability and accessibility.

Fixes #73