### PR TITLE
docs: update README and OpenAPI for metrics functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 View and chat to your Kubernetes cluster.
 
 
-Features a dashboard (with a K9s inspired dark theme and keyboard navigation), REST API, port forwarding management, and MCP server. In browser AI chat powered by the Copilot SDK (technical preview). 
+Features a dashboard (with a K9s inspired dark theme and keyboard navigation), REST API, port forwarding management, resource monitoring, and MCP server. In browser AI chat powered by the Copilot SDK (technical preview). 
 Integrates with VSCode and Copilot.
 
 ![img.png](docs/chat_1.png)
@@ -45,12 +45,22 @@ Manage Kubernetes port forwarding sessions directly from the dashboard or throug
 
 ![alt text](docs/portfwd.png)
 
+## Resource Monitoring
+
+Monitor CPU and memory usage for Nodes and Pods directly in the dashboard using interactive charts.
+
+- **Real-time Data**: Fetches live metrics from the Kubernetes Metrics Server.
+- **Node Metrics**: View cluster-wide resource utilization across all nodes.
+- **Pod Metrics**: Inspect resource consumption for individual pods in any namespace.
+- **Visual Charts**: Interactive Recharts-based visualizations for easier performance analysis.
+
 ## Table of Contents
 
 - [ST-K8s](#st-k8s)
   - [Keyboard Navigation](#keyboard-navigation)
   - [Log Viewer](#log-viewer)
   - [Port Forwarding](#port-forwarding)
+  - [Resource Monitoring](#resource-monitoring)
   - [Table of Contents](#table-of-contents)
   - [How to Run](#how-to-run)
     - [Using the `st-k8s` CLI](#using-the-st-k8s-cli)
@@ -168,6 +178,8 @@ Exposes read-only Kubernetes operations as tools:
 - `list_port_forwards`
 - `start_port_forward`
 - `stop_port_forward`
+- `get_node_metrics`
+- `get_pod_metrics`
 
 [Back to Top](#top)
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -677,6 +677,119 @@
         }
       }
     },
+    "/api/tools/k8s-metrics-status": {
+      "get": {
+        "summary": "Check if Kubernetes Metrics Server is available",
+        "operationId": "getMetricsStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ContextParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Metrics availability status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "available": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tools/k8s-metrics-nodes": {
+      "get": {
+        "summary": "Get resource usage metrics for cluster nodes",
+        "operationId": "getNodeMetrics",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ContextParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Node metrics list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/K8sNodeMetrics"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tools/k8s-metrics-pods": {
+      "get": {
+        "summary": "Get resource usage metrics for pods in a namespace",
+        "operationId": "getPodMetrics",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/NamespaceParam"
+          },
+          {
+            "$ref": "#/components/parameters/ContextParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pod metrics list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/K8sPodMetrics"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/tools/k8s-port-forward": {
       "get": {
         "summary": "List active port forwards",
@@ -902,6 +1015,66 @@
           },
           "isCurrent": {
             "type": "boolean"
+          }
+        }
+      },
+      "K8sNodeMetrics": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "cpu": {
+            "type": "string"
+          },
+          "memory": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "window": {
+            "type": "string"
+          }
+        }
+      },
+      "K8sPodMetrics": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "cpu": {
+            "type": "string"
+          },
+          "memory": {
+            "type": "string"
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "window": {
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
This PR updates the README and OpenAPI specification to include the newly implemented metrics and telemetry functionality.

Changes:
- Updated `README.md` with:
  - Resource Monitoring feature description.
  - New "Resource Monitoring" section details.
  - Added metrics tools (`get_node_metrics`, `get_pod_metrics`) to the MCP tools list.
  - Synchronized Table of Contents.
- Updated `public/openapi.json` with:
  - New endpoints: `/api/tools/k8s-metrics-status`, `/api/tools/k8s-metrics-nodes`, and `/api/tools/k8s-metrics-pods`.
  - New response schemas for node and pod metrics.