### PR TITLE
feat: implement LLM guardrails and tool usage restrictions

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -3,12 +3,12 @@ import { sendMessage } from "@/lib/copilot-service";
 
 export async function POST(req: NextRequest) {
   try {
-    const { message, model, attachments } = await req.json();
+    const { message, model, attachments, isReadOnly } = await req.json();
     if (!message) {
       return NextResponse.json({ error: "Message is required" }, { status: 400 });
     }
 
-    const response = await sendMessage(message, model, attachments);
+    const response = await sendMessage(message, model, attachments, isReadOnly);
     return NextResponse.json({ response });
   } catch (err: unknown) {
     console.error("Chat error:", err);

--- a/src/components/ChatComponent.tsx
+++ b/src/components/ChatComponent.tsx
@@ -46,6 +46,7 @@ export default function ChatComponent({
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isReadOnly, setIsReadOnly] = useState(true);
 
   const { attachedResources, removeAttachment } = useChat();
 
@@ -107,6 +108,7 @@ export default function ChatComponent({
         body: JSON.stringify({
           message: userMsg.content,
           model,
+          isReadOnly,
           attachments: attachedResources.map(r => ({
             name: r.name,
             type: r.type,
@@ -159,9 +161,53 @@ export default function ChatComponent({
     >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800 bg-zinc-950 rounded-tl-xl">
-        <div className="flex items-center gap-2">
-          <MessageCircle className="w-5 h-5 text-blue-400" />
-          <span className="font-semibold text-white text-lg">ST-K8s Chat</span>
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            <MessageCircle className="w-5 h-5 text-blue-400" />
+            <span className="font-semibold text-white text-lg">ST-K8s Chat</span>
+          </div>
+          <div className="flex items-center gap-2 mt-0.5">
+            <button
+              onClick={() => setIsReadOnly(!isReadOnly)}
+              className={`flex items-center gap-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded border transition-colors ${isReadOnly
+                ? "text-emerald-500 bg-emerald-500/10 border-emerald-500/20 hover:bg-emerald-500/20"
+                : "text-amber-500 bg-amber-500/10 border-amber-500/20 hover:bg-amber-500/20"
+                }`}
+              title={isReadOnly ? "Click to enable write operations" : "Click to enforce read-only mode"}
+            >
+              <Boxes className="w-2.5 h-2.5" />
+              {isReadOnly ? "Read-only" : "Write Enabled"}
+            </button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors uppercase font-medium">
+                  View Capabilities
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="bg-zinc-800 border-zinc-700 text-zinc-200 z-[70] w-56 p-2">
+                <div className="text-[10px] uppercase font-bold text-zinc-500 mb-1.5 px-2">Active Tools</div>
+                <div className="space-y-1 max-h-48 overflow-y-auto pr-1 custom-scrollbar">
+                  {[
+                    "list_namespaces", "list_pods", "list_deployments", "list_services",
+                    "list_nodes", "get_pod_logs", "list_events", "list_contexts",
+                    "list_configmaps", "list_jobs", "list_pvc",
+                    ...(isReadOnly ? [] : ["start_port_forward", "stop_port_forward", "list_port_forwards"])
+                  ].map(t => (
+                    <div key={t} className="text-[11px] px-2 py-1 rounded bg-zinc-900/50 border border-zinc-700/50 text-zinc-300">
+                      {t}
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-2 pt-2 border-t border-zinc-700 px-2">
+                  <p className="text-[10px] text-zinc-400 italic">
+                    {isReadOnly
+                      ? "All tools are restricted to read-only cluster operations for security."
+                      : "Writing operations and sensitive tools are enabled."}
+                  </p>
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <DropdownMenu>

--- a/src/lib/__tests__/copilot-service.test.ts
+++ b/src/lib/__tests__/copilot-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getSession, resetService } from "../copilot-service";
+import { CopilotClient } from "@github/copilot-sdk";
+
+// Mock the CopilotClient
+vi.mock("@github/copilot-sdk", () => {
+    const createSession = vi.fn().mockResolvedValue({
+        destroy: vi.fn(),
+    });
+    return {
+        CopilotClient: vi.fn().mockImplementation(function () {
+            return {
+                createSession,
+                getState: vi.fn().mockReturnValue("disconnected"),
+                start: vi.fn(),
+                listModels: vi.fn(),
+            };
+        }),
+        defineTool: vi.fn((name, config) => ({ name, ...config })),
+    };
+});
+
+describe("CopilotService Guardrails", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        resetService();
+    });
+
+    it("should include the strict system prompt during session creation", async () => {
+        await getSession("gpt-4o");
+
+        const CopilotClientMock = CopilotClient as any;
+        const clientInstance = CopilotClientMock.mock.results[0].value;
+        const createSessionSpy = clientInstance.createSession;
+
+        expect(createSessionSpy).toHaveBeenCalled();
+        const config = createSessionSpy.mock.calls[0][0];
+
+        expect(config.systemMessage).toBeDefined();
+        expect(config.systemMessage.mode).toBe("append");
+        expect(config.systemMessage.content).toContain("SECURITY GUARDRAILS");
+        expect(config.systemMessage.content).toContain("STRICTLY READ-ONLY");
+    });
+
+    it("should filter tools to read-only by default", async () => {
+        await getSession("gpt-4o", { readOnly: true });
+
+        const CopilotClientMock = CopilotClient as any;
+        const clientInstance = CopilotClientMock.mock.results[0].value;
+        const createSessionSpy = clientInstance.createSession;
+
+        const config = createSessionSpy.mock.calls[0][0];
+        const toolNames = config.tools.map((t: any) => t.name);
+
+        expect(toolNames).not.toContain("start_port_forward");
+        expect(toolNames).not.toContain("stop_port_forward");
+        expect(toolNames).toContain("list_pods");
+    });
+
+    it("should include operational tools when readOnly is false", async () => {
+        await getSession("gpt-4o", { readOnly: false });
+
+        const CopilotClientMock = CopilotClient as any;
+        const clientInstance = CopilotClientMock.mock.results[0].value; // Note: Singleton might cause issues here if not careful
+        const createSessionSpy = clientInstance.createSession;
+
+        // Since getSession uses a singleton, we might need to trigger a session change
+        // In the real implementation, changing options triggers a new session.
+
+        const config = createSessionSpy.mock.calls[createSessionSpy.mock.calls.length - 1][0];
+        const toolNames = config.tools.map((t: any) => t.name);
+
+        expect(toolNames).toContain("start_port_forward");
+        expect(toolNames).toContain("list_pods");
+    });
+});

--- a/src/lib/copilot-service.ts
+++ b/src/lib/copilot-service.ts
@@ -314,27 +314,78 @@ const getPodLogsTool = defineTool("get_pod_logs", {
     }
 });
 
+const SYSTEM_PROMPT = `
+You are an expert Kubernetes assistant for the ST-K8s dashboard. 
+Your primary goal is to help users understand, monitor, and troubleshoot their Kubernetes clusters.
+
+SECURITY GUARDRAILS:
+- You operate in a STRICTLY READ-ONLY environment.
+- You must NOT attempt to create, delete, or modify any Kubernetes resources (Pods, Deployments, Services, etc.).
+- If a user asks you to perform a mutative operation, politely explain that you are restricted to read-only actions for security reasons.
+- You can list resources, get logs, view configurations, and provide analysis based on the retrieved data.
+- Sensitive operational tools like port forwarding are excluded from your default capabilities.
+
+GUIDELINES:
+- Be concise and technical.
+- Provide YAML snippets or CLI commands for illustrative purposes when helpful, but always remind the user they must execute them manually if they intend to make changes.
+- Use the provided tools to fetch real-time data from the cluster.
+`;
+
+// Define tool lists by category
+const READ_ONLY_TOOLS = [
+    listContextsTool,
+    listNamespacesTool,
+    listPodsTool,
+    listDeploymentsTool,
+    listServicesTool,
+    listDaemonSetsTool,
+    listReplicaSetsTool,
+    listStatefulSetsTool,
+    listIngressesTool,
+    listEndpointsTool,
+    listEventsTool,
+    listPVCsTool,
+    listNodesTool,
+    listConfigMapsTool,
+    listJobsTool,
+    listCronJobsTool,
+    listServiceAccountsTool,
+    listRolesTool,
+    listRoleBindingsTool,
+    getPodLogsTool,
+];
+
+const OPERATIONAL_TOOLS = [
+    startPortForwardTool,
+    stopPortForwardTool,
+    listPortForwardsTool
+];
+
 // Singleton client/session management
-// Note: In serverless environment, this might be re-initialized.
-// Ideally, for a robust app, we-d persist session state or use a persistent server.
-// For this local dashboard, this global variable approach might work if next dev is used.
 let client: CopilotClient | null = null;
 type CopilotSession = Awaited<ReturnType<CopilotClient["createSession"]>>;
 let session: CopilotSession | null = null;
 let currentModel: string | null = null;
+let currentToolsHash: string | null = null;
 
-export async function getSession(model: string = "gpt-4o") {
-    console.log(`[CopilotService] getSession called with model: ${model}`);
-    console.log(`[CopilotService] Current active model: ${currentModel}`);
+function getToolsHash(tools: any[]) {
+    return tools.map(t => t.name).sort().join(",");
+}
 
-    if (session && currentModel === model) {
-        console.log(`[CopilotService] Reusing existing session for model: ${model}`);
+export async function getSession(model: string = "gpt-4o", options: { readOnly?: boolean } = { readOnly: true }) {
+    const readOnly = options.readOnly !== false;
+    const tools = !readOnly ? [...READ_ONLY_TOOLS, ...OPERATIONAL_TOOLS] : READ_ONLY_TOOLS;
+    const toolsHash = getToolsHash(tools) + (readOnly ? "-ro" : "-rw");
+
+    console.log(`[CopilotService] getSession called with model: ${model}, readOnly: ${readOnly}`);
+
+    if (session && currentModel === model && currentToolsHash === toolsHash) {
+        console.log(`[CopilotService] Reusing existing session`);
         return session;
     }
 
-    // If we have an existing session but need a different model, destroy the old one
     if (session) {
-        console.log(`[CopilotService] Destroying old session (model: ${currentModel}) to switch to ${model}`);
+        console.log(`[CopilotService] Destroying old session to re-configure`);
         try {
             await session.destroy();
         } catch (err) {
@@ -343,48 +394,40 @@ export async function getSession(model: string = "gpt-4o") {
         session = null;
     }
 
-    console.log(`[CopilotService] Creating NEW session for model: ${model}`);
-
     if (!client) {
         client = new CopilotClient({ logLevel: "info" });
     }
 
-    session = await client.createSession({
+    const sessionConfig: any = {
         model,
-        tools: [
-            listContextsTool,
-            listNamespacesTool,
-            listPodsTool,
-            listDeploymentsTool,
-            listServicesTool,
-            listDaemonSetsTool,
-            listReplicaSetsTool,
-            listStatefulSetsTool,
-            listIngressesTool,
-            listEndpointsTool,
-            listEventsTool,
-            listPVCsTool,
-            listNodesTool,
-            listConfigMapsTool,
-            listJobsTool,
-            listCronJobsTool,
-            listServiceAccountsTool,
-            listRolesTool,
-            listRoleBindingsTool,
-            getPodLogsTool,
-            startPortForwardTool,
-            stopPortForwardTool,
-            listPortForwardsTool
-        ]
-    });
+        tools,
+    };
+
+    if (readOnly) {
+        sessionConfig.systemMessage = {
+            mode: "append",
+            content: SYSTEM_PROMPT
+        };
+    }
+
+    session = await client.createSession(sessionConfig);
+
     currentModel = model;
-    console.log(`[CopilotService] Session created. currentModel updated to: ${currentModel}`);
+    currentToolsHash = toolsHash;
+    console.log(`[CopilotService] Session created with ${tools.length} tools and readOnly=${readOnly}`);
 
     return session;
 }
 
-export async function sendMessage(message: string, model: string = "gpt-4o", attachments?: { name: string, type: string, data: unknown }[]) {
-    const sess = await getSession(model);
+export function resetService() {
+    client = null;
+    session = null;
+    currentModel = null;
+    currentToolsHash = null;
+}
+
+export async function sendMessage(message: string, model: string = "gpt-4o", attachments?: { name: string, type: string, data: unknown }[], isReadOnly: boolean = true) {
+    const sess = await getSession(model, { readOnly: isReadOnly });
 
     let fullPrompt = message;
     if (attachments && attachments.length > 0) {


### PR DESCRIPTION
## Summary

Implements security guardrails for the Copilot chat integration as outlined in #98.

## Changes

### `src/lib/copilot-service.ts`
- Added a strict `SYSTEM_PROMPT` that explicitly restricts the LLM to read-only Kubernetes operations and directs it to refuse mutative requests.
- Refactored tool management into two categories: `READ_ONLY_TOOLS` (default, always available) and `OPERATIONAL_TOOLS` (port-forwarding, opt-in only).
- Updated `getSession(model, { readOnly })` — when `readOnly: true` (default), only read-only tools are registered and the system prompt is injected; when `false`, all tools are available and no system prompt is applied.
- Updated `sendMessage` to accept and forward `isReadOnly`.
- Exported `resetService()` for clean test isolation.

### `src/app/api/chat/route.ts`
- Extracts `isReadOnly` from the request body and forwards it to `sendMessage`.

### `src/components/ChatComponent.tsx`
- Added `isReadOnly` state (default: `true`).
- The **"Read-only"** badge is now a clickable toggle — green when active, amber ("Write Enabled") when off.
- The **"View Capabilities"** dropdown dynamically reflects which tools are active based on the current toggle state.
- `isReadOnly` is sent with every chat request.

### `src/lib/__tests__/copilot-service.test.ts` *(new)*
- Unit tests verifying system prompt injection and tool filtering behaviour.

## Test Results
- ✅ 115 unit tests passing
- ✅ 15 e2e tests passing  
- ✅ Production build succeeds

Closes #98