### PR TITLE
feat: chat session history archiving and management (#96)

### DIFF
--- a/src/components/ChatComponent.tsx
+++ b/src/components/ChatComponent.tsx
@@ -13,7 +13,12 @@ import {
   FileText,
   Boxes,
   Database,
-  Terminal
+  Terminal,
+  SquarePen,
+  Clock,
+  Trash2,
+  RotateCcw,
+  MessageSquare,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -22,15 +27,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useChat } from "./ChatContext";
-
-// Message type
-type Message = {
-  role: "user" | "assistant";
-  content: string;
-};
+import type { ChatSession } from "./ChatContext";
 
 interface ChatComponentProps {
-  isOpen?: boolean; // If parent controls visibility
+  isOpen?: boolean;
   onClose?: () => void;
 }
 
@@ -38,17 +38,26 @@ export default function ChatComponent({
   isOpen: controlledIsOpen,
   onClose,
 }: ChatComponentProps) {
-  // If controlled, use prop; else manage local state
   const [isOpen, setIsOpen] = useState<boolean>(!!controlledIsOpen);
-  const [messages, setMessages] = useState<Message[]>([]);
   const [model, setModel] = useState("gpt-4o");
   const [availableModels, setAvailableModels] = useState<{ id: string; name: string }[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isReadOnly, setIsReadOnly] = useState(true);
+  const [showHistory, setShowHistory] = useState(false);
 
-  const { attachedResources, removeAttachment } = useChat();
+  const {
+    messages,
+    setMessages,
+    attachedResources,
+    removeAttachment,
+    chatHistory,
+    startNewSession,
+    resumeSession,
+    deleteSession,
+    clearAllHistory,
+  } = useChat();
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -66,8 +75,6 @@ export default function ChatComponent({
           const data = await res.json();
           if (data.models && Array.isArray(data.models)) {
             setAvailableModels(data.models);
-            // Verify if current default model exists in the list?
-            // Not strictly necessary, but good UX.
           }
         }
       } catch (err) {
@@ -84,19 +91,27 @@ export default function ChatComponent({
     }
   }, [messages, loading]);
 
-  // Handle open/close
   const handleToggle = () => {
     if (controlledIsOpen === undefined) setIsOpen((v) => !v);
     else if (onClose && isOpen) onClose();
   };
 
-  // Send message to /api/chat
+  const handleNewChat = () => {
+    startNewSession();
+    setShowHistory(false);
+  };
+
+  const handleResumeSession = (session: ChatSession) => {
+    resumeSession(session);
+    setShowHistory(false);
+  };
+
   const sendMessage = async (e?: FormEvent) => {
     if (e) e.preventDefault();
     if (!input.trim() || loading) return;
     setError(null);
 
-    const userMsg: Message = { role: "user", content: input.trim() };
+    const userMsg = { role: "user" as const, content: input.trim() };
     setMessages((msgs) => [...msgs, userMsg]);
     setInput("");
     setLoading(true);
@@ -109,11 +124,11 @@ export default function ChatComponent({
           message: userMsg.content,
           model,
           isReadOnly,
-          attachments: attachedResources.map(r => ({
+          attachments: attachedResources.map((r) => ({
             name: r.name,
             type: r.type,
-            data: r.data
-          }))
+            data: r.data,
+          })),
         }),
       });
 
@@ -134,11 +149,20 @@ export default function ChatComponent({
     }
   };
 
-  // Keyboard: Enter to send
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       sendMessage();
     }
+  };
+
+  const formatTimestamp = (ts: number) => {
+    const date = new Date(ts);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    if (isToday) {
+      return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    }
+    return date.toLocaleDateString([], { month: "short", day: "numeric" });
   };
 
   // If closed, show floating button
@@ -192,7 +216,7 @@ export default function ChatComponent({
                     "list_nodes", "get_pod_logs", "list_events", "list_contexts",
                     "list_configmaps", "list_jobs", "list_pvc",
                     ...(isReadOnly ? [] : ["start_port_forward", "stop_port_forward", "list_port_forwards"])
-                  ].map(t => (
+                  ].map((t) => (
                     <div key={t} className="text-[11px] px-2 py-1 rounded bg-zinc-900/50 border border-zinc-700/50 text-zinc-300">
                       {t}
                     </div>
@@ -209,7 +233,33 @@ export default function ChatComponent({
             </DropdownMenu>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          {/* History toggle */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className={`text-zinc-400 hover:text-white w-8 h-8 relative ${showHistory ? "text-blue-400" : ""}`}
+            onClick={() => setShowHistory((v) => !v)}
+            aria-label="View chat history"
+            title="Chat history"
+          >
+            <Clock className="w-4 h-4" />
+            {chatHistory.length > 0 && !showHistory && (
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-blue-500 rounded-full" />
+            )}
+          </Button>
+          {/* New chat */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-zinc-400 hover:text-white w-8 h-8"
+            onClick={handleNewChat}
+            aria-label="Start new chat"
+            title="New chat"
+          >
+            <SquarePen className="w-4 h-4" />
+          </Button>
+          {/* Model selector */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -235,24 +285,9 @@ export default function ChatComponent({
                 ))
               ) : (
                 <>
-                  <DropdownMenuItem
-                    onClick={() => setModel("gpt-4o")}
-                    className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs"
-                  >
-                    GPT-4o
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => setModel("claude-3.5-sonnet")}
-                    className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs"
-                  >
-                    Claude 3.5 Sonnet
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => setModel("o1-mini")}
-                    className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs"
-                  >
-                    o1 Mini
-                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setModel("gpt-4o")} className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs">GPT-4o</DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setModel("claude-3.5-sonnet")} className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs">Claude 3.5 Sonnet</DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setModel("o1-mini")} className="focus:bg-zinc-700 focus:text-white cursor-pointer text-xs">o1 Mini</DropdownMenuItem>
                 </>
               )}
             </DropdownMenuContent>
@@ -260,7 +295,7 @@ export default function ChatComponent({
           <Button
             variant="ghost"
             size="icon"
-            className="text-zinc-400 hover:text-white"
+            className="text-zinc-400 hover:text-white w-8 h-8"
             onClick={handleToggle}
             aria-label="Close chat"
           >
@@ -269,56 +304,140 @@ export default function ChatComponent({
         </div>
       </div>
 
-      {/* Messages */}
-      <div
-        ref={scrollRef}
-        className="flex-1 overflow-y-auto px-4 py-3 space-y-3 bg-zinc-900"
-      >
-        {messages.length === 0 && (
-          <div className="text-zinc-400 text-center mt-8">
-            Start a conversation about your Kubernetes cluster.
+      {/* Body: History panel OR Messages */}
+      {showHistory ? (
+        <div className="flex-1 overflow-y-auto bg-zinc-900 flex flex-col">
+          {/* History header */}
+          <div className="flex items-center justify-between px-4 py-2.5 border-b border-zinc-800 sticky top-0 bg-zinc-900 z-10">
+            <span className="text-xs font-semibold text-zinc-300 uppercase tracking-wide">
+              Chat History
+              {chatHistory.length > 0 && (
+                <span className="ml-1.5 text-zinc-500 font-normal normal-case">
+                  ({chatHistory.length} session{chatHistory.length !== 1 ? "s" : ""})
+                </span>
+              )}
+            </span>
+            {chatHistory.length > 0 && (
+              <button
+                onClick={clearAllHistory}
+                className="flex items-center gap-1 text-[10px] text-red-400 hover:text-red-300 transition-colors uppercase font-bold px-1.5 py-0.5 rounded border border-red-500/20 hover:bg-red-500/10"
+                aria-label="Clear all history"
+              >
+                <Trash2 className="w-2.5 h-2.5" />
+                Clear All
+              </button>
+            )}
           </div>
-        )}
-        {messages.map((msg, idx) => (
-          <div
-            key={idx}
-            className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"
-              }`}
-          >
+
+          {/* History list */}
+          {chatHistory.length === 0 ? (
+            <div className="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 gap-3">
+              <MessageSquare className="w-10 h-10 text-zinc-700" />
+              <p className="text-zinc-500 text-sm">No archived sessions yet.</p>
+              <p className="text-zinc-600 text-xs">
+                Start a new chat to archive this session.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col divide-y divide-zinc-800/60">
+              {chatHistory.map((session) => (
+                <div
+                  key={session.id}
+                  className="group flex items-start gap-3 px-4 py-3 hover:bg-zinc-800/50 transition-colors"
+                >
+                  <MessageCircle className="w-4 h-4 text-zinc-600 mt-0.5 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-zinc-200 truncate font-medium leading-tight">
+                      {session.title}
+                    </p>
+                    <div className="flex items-center gap-2 mt-0.5">
+                      <span className="text-[10px] text-zinc-500">
+                        {formatTimestamp(session.timestamp)}
+                      </span>
+                      <span className="text-[10px] text-zinc-600">
+                        {session.messages.length} msg{session.messages.length !== 1 ? "s" : ""}
+                      </span>
+                      {session.attachments.length > 0 && (
+                        <span className="text-[10px] text-zinc-600">
+                          · {session.attachments.length} attachment{session.attachments.length !== 1 ? "s" : ""}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                    <button
+                      onClick={() => handleResumeSession(session)}
+                      className="p-1 rounded text-zinc-400 hover:text-emerald-400 hover:bg-emerald-500/10 transition-colors"
+                      aria-label={`Resume session: ${session.title}`}
+                      title="Resume session"
+                    >
+                      <RotateCcw className="w-3.5 h-3.5" />
+                    </button>
+                    <button
+                      onClick={() => deleteSession(session.id)}
+                      className="p-1 rounded text-zinc-400 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                      aria-label={`Delete session: ${session.title}`}
+                      title="Delete session"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        /* Messages */
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto px-4 py-3 space-y-3 bg-zinc-900"
+        >
+          {messages.length === 0 && (
+            <div className="text-zinc-400 text-center mt-8">
+              Start a conversation about your Kubernetes cluster.
+            </div>
+          )}
+          {messages.map((msg, idx) => (
             <div
-              className={`max-w-[80%] px-4 py-2 rounded-lg text-sm whitespace-pre-line ${msg.role === "user"
-                ? "bg-blue-600 text-white rounded-br-none"
-                : "bg-zinc-800 text-zinc-100 rounded-bl-none border border-zinc-700"
-                }`}
+              key={idx}
+              className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
             >
-              {msg.content}
+              <div
+                className={`max-w-[80%] px-4 py-2 rounded-lg text-sm whitespace-pre-line ${msg.role === "user"
+                  ? "bg-blue-600 text-white rounded-br-none"
+                  : "bg-zinc-800 text-zinc-100 rounded-bl-none border border-zinc-700"
+                  }`}
+              >
+                {msg.content}
+              </div>
             </div>
-          </div>
-        ))}
-        {loading && (
-          <div className="flex justify-start">
-            <div className="flex items-center gap-2 bg-zinc-800 text-zinc-300 px-4 py-2 rounded-lg border border-zinc-700">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              <span>Assistant is typing...</span>
+          ))}
+          {loading && (
+            <div className="flex justify-start">
+              <div className="flex items-center gap-2 bg-zinc-800 text-zinc-300 px-4 py-2 rounded-lg border border-zinc-700">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>Assistant is typing...</span>
+              </div>
             </div>
-          </div>
-        )}
-        {error && (
-          <div className="flex justify-center" role="alert">
-            <div className="text-red-400 text-xs mt-2">{error}</div>
-          </div>
-        )}
-      </div>
+          )}
+          {error && (
+            <div className="flex justify-center" role="alert">
+              <div className="text-red-400 text-xs mt-2">{error}</div>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Attachments Area */}
-      {attachedResources.length > 0 && (
+      {!showHistory && attachedResources.length > 0 && (
         <div className="px-4 py-2 bg-zinc-950 border-t border-zinc-800 flex flex-wrap gap-2 max-h-24 overflow-y-auto">
           {attachedResources.map((res) => {
             const getIcon = () => {
               switch (res.type) {
-                case 'log-snippet': return <Terminal className="w-3 h-3" />;
-                case 'collection': return <Boxes className="w-3 h-3" />;
-                case 'resource': return <Database className="w-3 h-3" />;
+                case "log-snippet": return <Terminal className="w-3 h-3" />;
+                case "collection": return <Boxes className="w-3 h-3" />;
+                case "resource": return <Database className="w-3 h-3" />;
                 default: return <FileText className="w-3 h-3" />;
               }
             };
@@ -344,35 +463,37 @@ export default function ChatComponent({
         </div>
       )}
 
-      {/* Input */}
-      <form
-        onSubmit={sendMessage}
-        className="flex items-center gap-2 px-4 py-3 border-t border-zinc-800 bg-zinc-950"
-      >
-        <Input
-          className="flex-1 bg-zinc-800 text-white border-zinc-700 placeholder:text-zinc-400"
-          placeholder="Type your message..."
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={loading}
-          autoComplete="off"
-          aria-label="Chat input"
-        />
-        <Button
-          type="submit"
-          size="icon"
-          className="bg-[#368dab] hover:bg-[#2a6f87] text-white"
-          disabled={loading || !input.trim()}
-          aria-label="Send message"
+      {/* Input — hidden when history panel is open */}
+      {!showHistory && (
+        <form
+          onSubmit={sendMessage}
+          className="flex items-center gap-2 px-4 py-3 border-t border-zinc-800 bg-zinc-950"
         >
-          {loading ? (
-            <Loader2 className="w-5 h-5 animate-spin" />
-          ) : (
-            <Send className="w-5 h-5" />
-          )}
-        </Button>
-      </form>
+          <Input
+            className="flex-1 bg-zinc-800 text-white border-zinc-700 placeholder:text-zinc-400"
+            placeholder="Type your message..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={loading}
+            autoComplete="off"
+            aria-label="Chat input"
+          />
+          <Button
+            type="submit"
+            size="icon"
+            className="bg-[#368dab] hover:bg-[#2a6f87] text-white"
+            disabled={loading || !input.trim()}
+            aria-label="Send message"
+          >
+            {loading ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <Send className="w-5 h-5" />
+            )}
+          </Button>
+        </form>
+      )}
     </Card>
   );
 }

--- a/src/components/ChatContext.tsx
+++ b/src/components/ChatContext.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from "react";
+import React, {
+    createContext,
+    useContext,
+    useState,
+    useCallback,
+    ReactNode,
+    useEffect,
+} from "react";
+
+// ---------- shared types ----------
 
 export interface AttachedResource {
     id: string;
@@ -9,44 +18,112 @@ export interface AttachedResource {
     data: unknown;
 }
 
+export interface ChatMessage {
+    role: "user" | "assistant";
+    content: string;
+}
+
+export interface ChatSession {
+    id: string;
+    /** Title derived from the first user message (truncated). */
+    title: string;
+    timestamp: number;
+    messages: ChatMessage[];
+    attachments: AttachedResource[];
+}
+
+// ---------- context shape ----------
+
 interface ChatContextType {
+    // Active messages
+    messages: ChatMessage[];
+    setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+
+    // Attachments
     attachedResources: AttachedResource[];
     addAttachment: (resource: Omit<AttachedResource, "id">) => void;
     removeAttachment: (id: string) => void;
     clearAttachments: () => void;
+
+    // Session history
+    chatHistory: ChatSession[];
+    startNewSession: () => void;
+    resumeSession: (session: ChatSession) => void;
+    deleteSession: (id: string) => void;
+    clearAllHistory: () => void;
 }
+
+const STORAGE_KEY_ATTACHMENTS = "chat_attachments";
+const STORAGE_KEY_SESSIONS = "chat_sessions";
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
-export function ChatProvider({ children }: { children: ReactNode }) {
-    const [attachedResources, setAttachedResources] = useState<AttachedResource[]>(() => {
-        // Initial load from localStorage
-        if (typeof window !== "undefined") {
-            const saved = localStorage.getItem("chat_attachments");
-            if (saved) {
-                try {
-                    return JSON.parse(saved);
-                } catch (e) {
-                    console.error("Failed to parse saved chat attachments", e);
-                }
-            }
-        }
-        return [];
-    });
+// ---------- helpers ----------
 
-    // Persist to localStorage
+function loadFromStorage<T>(key: string, fallback: T): T {
+    if (typeof window === "undefined") return fallback;
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    try {
+        return JSON.parse(raw) as T;
+    } catch {
+        return fallback;
+    }
+}
+
+function sessionTitle(messages: ChatMessage[]): string {
+    const first = messages.find((m) => m.role === "user");
+    if (!first) return "Untitled session";
+    return first.content.length > 50
+        ? first.content.slice(0, 50) + "…"
+        : first.content;
+}
+
+// ---------- provider ----------
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+    const [messages, setMessages] = useState<ChatMessage[]>(() =>
+        loadFromStorage<ChatMessage[]>("chat_active_messages", [])
+    );
+
+    const [attachedResources, setAttachedResources] = useState<AttachedResource[]>(() =>
+        loadFromStorage<AttachedResource[]>(STORAGE_KEY_ATTACHMENTS, [])
+    );
+
+    const [chatHistory, setChatHistory] = useState<ChatSession[]>(() =>
+        loadFromStorage<ChatSession[]>(STORAGE_KEY_SESSIONS, [])
+    );
+
+    // Persist active messages
     useEffect(() => {
-        localStorage.setItem("chat_attachments", JSON.stringify(attachedResources));
+        localStorage.setItem("chat_active_messages", JSON.stringify(messages));
+    }, [messages]);
+
+    // Persist attachments
+    useEffect(() => {
+        localStorage.setItem(STORAGE_KEY_ATTACHMENTS, JSON.stringify(attachedResources));
     }, [attachedResources]);
 
-    // Sync across tabs
+    // Persist history
+    useEffect(() => {
+        localStorage.setItem(STORAGE_KEY_SESSIONS, JSON.stringify(chatHistory));
+    }, [chatHistory]);
+
+    // Cross-tab sync for attachments
     useEffect(() => {
         const handleStorage = (e: StorageEvent) => {
-            if (e.key === "chat_attachments" && e.newValue) {
+            if (e.key === STORAGE_KEY_ATTACHMENTS && e.newValue) {
                 try {
                     setAttachedResources(JSON.parse(e.newValue));
                 } catch (err) {
-                    console.error("Sync error", err);
+                    console.error("Sync error (attachments)", err);
+                }
+            }
+            if (e.key === STORAGE_KEY_SESSIONS && e.newValue) {
+                try {
+                    setChatHistory(JSON.parse(e.newValue));
+                } catch (err) {
+                    console.error("Sync error (sessions)", err);
                 }
             }
         };
@@ -54,19 +131,18 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         return () => window.removeEventListener("storage", handleStorage);
     }, []);
 
+    // ----- attachment operations -----
+
     const addAttachment = useCallback((resource: Omit<AttachedResource, "id">) => {
         setAttachedResources((prev) => {
-            // Avoid duplicates based on name and type
             const exists = prev.some(
                 (r) => r.name === resource.name && r.type === resource.type
             );
             if (exists) return prev;
-
-            const newAttachment: AttachedResource = {
-                ...resource,
-                id: `${resource.type}-${resource.name}-${Date.now()}`,
-            };
-            return [...prev, newAttachment];
+            return [
+                ...prev,
+                { ...resource, id: `${resource.type}-${resource.name}-${Date.now()}` },
+            ];
         });
     }, []);
 
@@ -78,13 +154,80 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         setAttachedResources([]);
     }, []);
 
+    // ----- session operations -----
+
+    const startNewSession = useCallback(() => {
+        // Archive current session only if it has at least one message
+        setMessages((currentMessages) => {
+            if (currentMessages.length > 0) {
+                const session: ChatSession = {
+                    id: `session-${Date.now()}`,
+                    title: sessionTitle(currentMessages),
+                    timestamp: Date.now(),
+                    messages: currentMessages,
+                    attachments: [],
+                };
+                // Capture current attachments snapshot for the archive
+                setAttachedResources((currentAttachments) => {
+                    session.attachments = [...currentAttachments];
+                    setChatHistory((prev) => [session, ...prev]);
+                    return []; // clear attachments
+                });
+            }
+            return []; // clear messages
+        });
+    }, []);
+
+    const resumeSession = useCallback((session: ChatSession) => {
+        // Archive the current active session first (if non-empty), then load the chosen one
+        setMessages((currentMessages) => {
+            if (currentMessages.length > 0) {
+                const archived: ChatSession = {
+                    id: `session-${Date.now()}`,
+                    title: sessionTitle(currentMessages),
+                    timestamp: Date.now(),
+                    messages: currentMessages,
+                    attachments: [],
+                };
+                setAttachedResources((currentAttachments) => {
+                    archived.attachments = [...currentAttachments];
+                    setChatHistory((prev) => [
+                        archived,
+                        ...prev.filter((s) => s.id !== session.id),
+                    ]);
+                    return session.attachments; // restore session attachments
+                });
+            } else {
+                // Just remove the session from history and load it
+                setChatHistory((prev) => prev.filter((s) => s.id !== session.id));
+                setAttachedResources(session.attachments);
+            }
+            return session.messages;
+        });
+    }, []);
+
+    const deleteSession = useCallback((id: string) => {
+        setChatHistory((prev) => prev.filter((s) => s.id !== id));
+    }, []);
+
+    const clearAllHistory = useCallback(() => {
+        setChatHistory([]);
+    }, []);
+
     return (
         <ChatContext.Provider
             value={{
+                messages,
+                setMessages,
                 attachedResources,
                 addAttachment,
                 removeAttachment,
                 clearAttachments,
+                chatHistory,
+                startNewSession,
+                resumeSession,
+                deleteSession,
+                clearAllHistory,
             }}
         >
             {children}

--- a/src/components/__tests__/ChatContext.test.tsx
+++ b/src/components/__tests__/ChatContext.test.tsx
@@ -1,128 +1,229 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { ChatProvider, useChat } from '../ChatContext';
+import type { ChatSession } from '../ChatContext';
 import React from 'react';
 
+// ----------------------------------------------------------------
+// Helper component that exercises all context operations
+// ----------------------------------------------------------------
 const TestComponent = () => {
-    const { attachedResources, addAttachment, removeAttachment, clearAttachments } = useChat();
+    const {
+        messages, setMessages,
+        attachedResources, addAttachment, removeAttachment, clearAttachments,
+        chatHistory, startNewSession, resumeSession, deleteSession, clearAllHistory,
+    } = useChat();
+
     return (
         <div>
-            <div data-testid="count">{attachedResources.length}</div>
-            <div data-testid="resources">
-                {attachedResources.map(r => <div key={r.id}>{r.name}</div>)}
-            </div>
-            <button onClick={() => addAttachment({ name: 'res-1', type: 'pod', data: {} })}>Add</button>
-            <button onClick={() => removeAttachment(attachedResources[0]?.id)}>Remove</button>
-            <button onClick={() => clearAttachments()}>Clear</button>
+            {/* Messages */}
+            <div data-testid="msg-count">{messages.length}</div>
+            <div data-testid="messages">{messages.map((m, i) => <div key={i}>{m.content}</div>)}</div>
+
+            {/* Attachments */}
+            <div data-testid="att-count">{attachedResources.length}</div>
+            <div data-testid="resources">{attachedResources.map(r => <div key={r.id}>{r.name}</div>)}</div>
+
+            {/* History */}
+            <div data-testid="history-count">{chatHistory.length}</div>
+            <div data-testid="history">{chatHistory.map(s => <div key={s.id} data-testid={`session-${s.id}`}>{s.title}</div>)}</div>
+
+            {/* Actions */}
+            <button onClick={() => setMessages([{ role: 'user', content: 'hello' }])}>AddMsg</button>
+            <button onClick={() => addAttachment({ name: 'res-1', type: 'pod', data: {} })}>AddAtt</button>
+            <button onClick={() => removeAttachment(attachedResources[0]?.id)}>RemoveAtt</button>
+            <button onClick={() => clearAttachments()}>ClearAtt</button>
+            <button onClick={() => startNewSession()}>NewChat</button>
+            <button onClick={() => chatHistory[0] && resumeSession(chatHistory[0])}>Resume</button>
+            <button onClick={() => chatHistory[0] && deleteSession(chatHistory[0].id)}>Delete</button>
+            <button onClick={() => clearAllHistory()}>ClearHistory</button>
         </div>
     );
 };
 
+// ----------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------
 describe('ChatProvider', () => {
+    let store: Record<string, string>;
+
     beforeEach(() => {
         vi.clearAllMocks();
-        const store: Record<string, string> = {};
-        vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => store[key] || null);
+        store = {};
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => store[key] ?? null);
         vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key, value) => { store[key] = value; });
+        vi.spyOn(Storage.prototype, 'removeItem').mockImplementation((key) => { delete store[key]; });
     });
 
-    it('loads initial state from localStorage', () => {
+    // ---- attachments (backwards-compatible) ----
+
+    it('loads initial attachments from localStorage', () => {
         const initialData = [{ id: '1', name: 'saved-res', type: 'pod', data: {} }];
-        localStorage.setItem('chat_attachments', JSON.stringify(initialData));
+        store['chat_attachments'] = JSON.stringify(initialData);
 
-        render(
-            <ChatProvider>
-                <TestComponent />
-            </ChatProvider>
-        );
+        render(<ChatProvider><TestComponent /></ChatProvider>);
 
-        expect(screen.getByTestId('count').textContent).toBe('1');
+        expect(screen.getByTestId('att-count').textContent).toBe('1');
         expect(screen.getByText('saved-res')).toBeInTheDocument();
     });
 
     it('adds and persists attachments', () => {
-        render(
-            <ChatProvider>
-                <TestComponent />
-            </ChatProvider>
-        );
+        render(<ChatProvider><TestComponent /></ChatProvider>);
 
-        act(() => {
-            screen.getByText('Add').click();
-        });
+        act(() => { screen.getByText('AddAtt').click(); });
 
-        expect(screen.getByTestId('count').textContent).toBe('1');
+        expect(screen.getByTestId('att-count').textContent).toBe('1');
         expect(localStorage.setItem).toHaveBeenCalledWith('chat_attachments', expect.stringContaining('res-1'));
     });
 
     it('prevents duplicate attachments', () => {
-        render(
-            <ChatProvider>
-                <TestComponent />
-            </ChatProvider>
-        );
+        render(<ChatProvider><TestComponent /></ChatProvider>);
 
         act(() => {
-            screen.getByText('Add').click();
-            screen.getByText('Add').click();
+            screen.getByText('AddAtt').click();
+            screen.getByText('AddAtt').click();
         });
 
-        expect(screen.getByTestId('count').textContent).toBe('1');
+        expect(screen.getByTestId('att-count').textContent).toBe('1');
     });
 
     it('removes attachments', () => {
-        render(
-            <ChatProvider>
-                <TestComponent />
-            </ChatProvider>
-        );
+        render(<ChatProvider><TestComponent /></ChatProvider>);
 
-        act(() => {
-            screen.getByText('Add').click();
-        });
-        expect(screen.getByTestId('count').textContent).toBe('1');
+        act(() => { screen.getByText('AddAtt').click(); });
+        expect(screen.getByTestId('att-count').textContent).toBe('1');
 
-        act(() => {
-            screen.getByText('Remove').click();
-        });
-        expect(screen.getByTestId('count').textContent).toBe('0');
+        act(() => { screen.getByText('RemoveAtt').click(); });
+        expect(screen.getByTestId('att-count').textContent).toBe('0');
     });
 
     it('clears all attachments', () => {
-        render(
-            <ChatProvider>
-                <TestComponent />
-            </ChatProvider>
-        );
+        render(<ChatProvider><TestComponent /></ChatProvider>);
 
-        act(() => {
-            screen.getByText('Add').click();
-        });
+        act(() => { screen.getByText('AddAtt').click(); });
+        act(() => { screen.getByText('ClearAtt').click(); });
 
-        act(() => {
-            screen.getByText('Clear').click();
-        });
-        expect(screen.getByTestId('count').textContent).toBe('0');
+        expect(screen.getByTestId('att-count').textContent).toBe('0');
     });
 
-    it('syncs across tabs via storage event', () => {
-        render(
-            <ChatProvider>
-                <TestComponent />
-            </ChatProvider>
-        );
+    it('syncs attachments across tabs via storage event', () => {
+        render(<ChatProvider><TestComponent /></ChatProvider>);
 
         const newData = [{ id: 'sync-1', name: 'synced-res', type: 'pod', data: {} }];
 
         act(() => {
             window.dispatchEvent(new StorageEvent('storage', {
                 key: 'chat_attachments',
-                newValue: JSON.stringify(newData)
+                newValue: JSON.stringify(newData),
             }));
         });
 
-        expect(screen.getByTestId('count').textContent).toBe('1');
+        expect(screen.getByTestId('att-count').textContent).toBe('1');
         expect(screen.getByText('synced-res')).toBeInTheDocument();
+    });
+
+    // ---- session / history ----
+
+    it('startNewSession archives current messages and clears them', () => {
+        render(<ChatProvider><TestComponent /></ChatProvider>);
+
+        act(() => { screen.getByText('AddMsg').click(); });
+        expect(screen.getByTestId('msg-count').textContent).toBe('1');
+
+        act(() => { screen.getByText('NewChat').click(); });
+
+        expect(screen.getByTestId('msg-count').textContent).toBe('0');
+        expect(screen.getByTestId('history-count').textContent).toBe('1');
+    });
+
+    it('startNewSession does NOT archive when messages are empty', () => {
+        render(<ChatProvider><TestComponent /></ChatProvider>);
+
+        // No messages added
+        act(() => { screen.getByText('NewChat').click(); });
+
+        expect(screen.getByTestId('history-count').textContent).toBe('0');
+    });
+
+    it('deleteSession removes the correct session', () => {
+        render(<ChatProvider><TestComponent /></ChatProvider>);
+
+        // Create two sessions
+        act(() => { screen.getByText('AddMsg').click(); });
+        act(() => { screen.getByText('NewChat').click(); });
+        act(() => { screen.getByText('AddMsg').click(); });
+        act(() => { screen.getByText('NewChat').click(); });
+
+        expect(screen.getByTestId('history-count').textContent).toBe('2');
+
+        act(() => { screen.getByText('Delete').click(); }); // deletes most-recent (index 0)
+
+        expect(screen.getByTestId('history-count').textContent).toBe('1');
+    });
+
+    it('clearAllHistory removes all sessions', () => {
+        render(<ChatProvider><TestComponent /></ChatProvider>);
+
+        act(() => { screen.getByText('AddMsg').click(); });
+        act(() => { screen.getByText('NewChat').click(); });
+
+        act(() => { screen.getByText('ClearHistory').click(); });
+
+        expect(screen.getByTestId('history-count').textContent).toBe('0');
+    });
+
+    it('resumeSession restores messages and removes session from history', () => {
+        render(<ChatProvider><TestComponent /></ChatProvider>);
+
+        // Create an archived session
+        act(() => { screen.getByText('AddMsg').click(); });
+        act(() => { screen.getByText('NewChat').click(); });
+
+        expect(screen.getByTestId('history-count').textContent).toBe('1');
+        expect(screen.getByTestId('msg-count').textContent).toBe('0');
+
+        act(() => { screen.getByText('Resume').click(); });
+
+        expect(screen.getByTestId('msg-count').textContent).toBe('1');
+        expect(screen.getByTestId('history-count').textContent).toBe('0');
+    });
+
+    it('loads chatHistory from localStorage on init', () => {
+        const session: ChatSession = {
+            id: 'test-session',
+            title: 'Test session',
+            timestamp: Date.now(),
+            messages: [{ role: 'user', content: 'hi' }],
+            attachments: [],
+        };
+        store['chat_sessions'] = JSON.stringify([session]);
+
+        render(<ChatProvider><TestComponent /></ChatProvider>);
+
+        expect(screen.getByTestId('history-count').textContent).toBe('1');
+        expect(screen.getByText('Test session')).toBeInTheDocument();
+    });
+
+    it('syncs chatHistory across tabs via storage event', () => {
+        render(<ChatProvider><TestComponent /></ChatProvider>);
+
+        const session: ChatSession = {
+            id: 'tab-session',
+            title: 'Tab session',
+            timestamp: Date.now(),
+            messages: [{ role: 'user', content: 'cross-tab' }],
+            attachments: [],
+        };
+
+        act(() => {
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: 'chat_sessions',
+                newValue: JSON.stringify([session]),
+            }));
+        });
+
+        expect(screen.getByTestId('history-count').textContent).toBe('1');
+        expect(screen.getByText('Tab session')).toBeInTheDocument();
     });
 
     it('throws error when useChat is used outside of Provider', () => {


### PR DESCRIPTION
Closes #96

## Summary

Implements full chat session history archiving and management in the chat UI.

## Changes

### `ChatContext.tsx` (rewrite)
- Moves `messages` state **into the context** (was local to `ChatComponent`) — required for session operations to work
- Adds `ChatSession` type: `{ id, title, timestamp, messages, attachments }`
- Persists active messages to `localStorage` key `chat_active_messages`
- Persists session archive to `localStorage` key `chat_sessions`
- Cross-tab storage sync for both attachments and session history
- New context operations:
  - `startNewSession()` — archives current session (if non-empty), clears state
  - `resumeSession(session)` — restores a historical session, archives current if non-empty
  - `deleteSession(id)` — removes a specific session from history
  - `clearAllHistory()` — bulk-deletes all archived sessions

### `ChatComponent.tsx` (rewrite)
- Sources `messages` from `useChat()` instead of local state
- **New Chat** button (`SquarePen` icon) in the header → calls `startNewSession()`
- **History** button (`Clock` icon) in the header → toggles the history panel; shows a blue dot badge when sessions exist
- History panel (replaces the message area while open):
  - Lists all archived sessions with title (truncated first user message), timestamp, and message count
  - Each row shows **Resume** and **Delete** action buttons on hover
  - **Clear All History** button in the panel header
  - Empty state illustration when no sessions exist
- Input and attachments area are hidden while the history panel is open

### `ChatContext.test.tsx`
- 14 tests total (up from 6), all passing
- New coverage: `startNewSession`, `deleteSession`, `clearAllHistory`, `resumeSession`, localStorage init for history, cross-tab sync for history

## Acceptance criteria

| Criterion | Status |
|---|---|
| "New Chat" button in Chat UI | ✅ |
| Clears active chat state and context on new session | ✅ |
| Archives current session to localStorage | ✅ |
| "History" view lists previous sessions | ✅ |
| Click a session to resume (view + restore) | ✅ |
| Delete specific sessions | ✅ |
| "Clear All History" bulk delete | ✅ |
| UI reflects changes immediately | ✅ |

## Test results

```
Test Files  23 passed (23)
     Tests  122 passed (122)
```

Zero TypeScript errors (`tsc --noEmit`).
