### PR TITLE
chore: add homebrew tap setup, semver, and footer version display

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        
+      - name: Create release archive
+        run: |
+          TARBALL_NAME="st-k8s-${{ github.ref_name }}.tar.gz"
+          # Create archive of the current source state
+          git archive -o $TARBALL_NAME HEAD
+          
+          # Calculate SHA256 of the tarball
+          # Linux gives 'abc... filename' so we capture just the checksum
+          SHA256=$(sha256sum $TARBALL_NAME | awk '{print $1}')
+          
+          echo "TARBALL_NAME=$TARBALL_NAME" >> $GITHUB_ENV
+          echo "SHA256=$SHA256" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.ref_name }}
+          files: ${{ env.TARBALL_NAME }}
+          draft: false
+          prerelease: false
+
+      - name: Update Homebrew tap formula
+        env:
+          TAP_REPO: bhf/homebrew-st-k8s
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION=${{ github.ref_name }}
+          VERSION=${VERSION#v} # remove 'v' prefix for formula version
+          
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${TAP_REPO}.git tap-repo
+          cd tap-repo
+          
+          # The URL of the release asset we just uploaded
+          ASSET_URL="https://github.com/bhf/st-k8s/releases/download/${{ github.ref_name }}/${{ env.TARBALL_NAME }}"
+          
+          mkdir -p Formula
+          
+          cat > Formula/st-k8s.rb << EOF
+          class StK8s < Formula
+            desc "View and chat to your Kubernetes cluster"
+            homepage "https://github.com/bhf/st-k8s"
+            url "$ASSET_URL"
+            sha256 "${{ env.SHA256 }}"
+            license "MIT"
+            version "$VERSION"
+          
+            depends_on "node"
+          
+            def install
+              system "npm", "ci", "--ignore-scripts"
+              system "npm", "run", "build"
+              bin.install "bin/st-k8s"
+              prefix.install_metafiles
+            end
+          
+            test do
+              system "#{bin}/st-k8s", "--version"
+            end
+          end
+          EOF
+          
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git add Formula/st-k8s.rb
+          git commit -m "chore: bump st-k8s to ${{ github.ref_name }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ Monitor CPU and memory usage for Nodes and Pods directly in the dashboard using 
 
 ## How to Run
 
+### Using Homebrew (macOS/Linux)
+
+The easiest way to install and run `st-k8s` is via Homebrew:
+
+```bash
+brew tap bhf/st-k8s
+brew install st-k8s
+st-k8s
+```
+
+### From Source
+
 To use the browser based chat feature make sure you install the [Copilot CLI](https://github.com/github/copilot-cli).
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st-k8s",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "bin": {
     "st-k8s": "bin/st-k8s"

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+// Embedded at build time from package.json
+const CURRENT_VERSION = process.env.npm_package_version ?? "1.0.0";
+
+const GITHUB_RELEASES_URL =
+    "https://api.github.com/repos/bhf/st-k8s/releases/latest";
+
+// Cache the upstream version check for 1 hour to avoid hammering the API
+let cachedLatest: { version: string; fetchedAt: number } | null = null;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+async function getLatestVersion(): Promise<string | null> {
+    const now = Date.now();
+    if (cachedLatest && now - cachedLatest.fetchedAt < CACHE_TTL_MS) {
+        return cachedLatest.version;
+    }
+
+    try {
+        const res = await fetch(GITHUB_RELEASES_URL, {
+            headers: { Accept: "application/vnd.github+json" },
+            // next.js fetch cache — revalidate every hour
+            next: { revalidate: 3600 },
+        });
+        if (!res.ok) return null;
+        const data = await res.json();
+        const tag: string = data.tag_name ?? "";
+        const version = tag.startsWith("v") ? tag.slice(1) : tag;
+        if (version) {
+            cachedLatest = { version, fetchedAt: now };
+        }
+        return version || null;
+    } catch {
+        return null;
+    }
+}
+
+function isNewer(latest: string, current: string): boolean {
+    const parse = (v: string) => v.split(".").map(Number);
+    const [maj1, min1, pat1] = parse(latest);
+    const [maj2, min2, pat2] = parse(current);
+    if (maj1 !== maj2) return maj1 > maj2;
+    if (min1 !== min2) return min1 > min2;
+    return pat1 > pat2;
+}
+
+export async function GET() {
+    const latestVersion = await getLatestVersion();
+    const updateAvailable =
+        latestVersion !== null && isNewer(latestVersion, CURRENT_VERSION);
+
+    return NextResponse.json({
+        version: CURRENT_VERSION,
+        latestVersion,
+        updateAvailable,
+    });
+}

--- a/src/app/k8s-dashboard/Footer.tsx
+++ b/src/app/k8s-dashboard/Footer.tsx
@@ -51,12 +51,18 @@ export default function Footer({
 }: FooterProps) {
   const [projectPath, setProjectPath] = useState<string>("");
   const [copied, setCopied] = useState(false);
+  const [versionInfo, setVersionInfo] = useState<{ version: string; latestVersion: string | null; updateAvailable: boolean } | null>(null);
 
   useEffect(() => {
     const url = new URL("/api/config", window.location.origin);
     fetch(url.toString())
       .then((res) => res.json())
       .then((data) => setProjectPath(data.projectPath || ""))
+      .catch(console.error);
+
+    fetch("/api/version")
+      .then((res) => res.json())
+      .then((data) => setVersionInfo(data))
       .catch(console.error);
   }, []);
 
@@ -143,6 +149,26 @@ export default function Footer({
       </div>
 
       <div className="flex items-center gap-4 shrink-0 px-2 ml-auto">
+        {versionInfo && (
+          <>
+            {versionInfo.updateAvailable ? (
+              <a
+                href="https://github.com/bhf/st-k8s/releases"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 font-mono text-[9px] text-amber-500 hover:text-amber-400 transition-colors bg-amber-500/10 px-1.5 py-0.5 rounded border border-amber-500/20"
+                title={`Update available: v${versionInfo.latestVersion}`}
+              >
+                ↑ v{versionInfo.latestVersion}
+              </a>
+            ) : (
+              <div className="font-mono text-[9px] text-zinc-500" title="Current version">
+                v{versionInfo.version}
+              </div>
+            )}
+            <div className="w-px h-3 bg-zinc-800 mx-1" />
+          </>
+        )}
         <div className="flex items-center gap-1.5 font-mono text-[9px] text-zinc-500 mr-2">
           © 2026 <a href="https://sanjeev.pages.dev/" target="_blank" rel="noopener noreferrer" className="hover:text-zinc-300 transition-colors">StayTuned</a>
         </div>

--- a/src/app/k8s-dashboard/__tests__/Footer.test.tsx
+++ b/src/app/k8s-dashboard/__tests__/Footer.test.tsx
@@ -41,4 +41,36 @@ describe('Footer', () => {
     render(<Footer {...defaultProps} isLoadingNamespaces={true} />)
     expect(screen.getByRole('combobox', { name: /namespace/i })).toBeDisabled()
   })
+
+  it('renders current version', async () => {
+    const mockFetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/version') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ version: '1.0.0', latestVersion: '1.0.0', updateAvailable: false })
+        })
+      }
+      return Promise.resolve({ json: () => Promise.resolve({}) })
+    })
+    global.fetch = mockFetch
+
+    render(<Footer {...defaultProps} />)
+    expect(await screen.findByText('v1.0.0')).toBeDefined()
+    global.fetch = vi.restoreAllMocks as any
+  })
+
+  it('renders update available badge', async () => {
+    const mockFetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/version') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ version: '1.0.0', latestVersion: '1.1.0', updateAvailable: true })
+        })
+      }
+      return Promise.resolve({ json: () => Promise.resolve({}) })
+    })
+    global.fetch = mockFetch
+
+    render(<Footer {...defaultProps} />)
+    expect(await screen.findByText('↑ v1.1.0')).toBeDefined()
+    global.fetch = vi.restoreAllMocks as any
+  })
 })


### PR DESCRIPTION
This PR implements the following:
- Bumps version to \`1.0.0\` in \`package.json\`
- Adds a new server route \`/api/version\` that exposes the current running version and determines if there is an update available by querying standard GitHub releases
- Updates the application Footer to render the active version, plus an "Update Available" badge when there is a new GitHub release
- Automates the release lifecycle through a new GitHub Actions workflow (\`.github/workflows/release.yml\`) to package the source, draft a GH release, branch out, and push a formula update to the new \`bhf/homebrew-st-k8s\` tap.
- Adds Homebrew installation instructions to the \`README.md\`.

> [!WARNING]
> Please remember to set the \`HOMEBREW_TAP_TOKEN\` repository secret with a valid GitHub PAT before drafting the \`1.0.0\` tag so the pipeline can successfully clone and push the tap formula!