### PR TITLE
fix: resolve correct internal paths for st-k8s brew binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,9 @@ jobs:
             def install
               system "npm", "ci", "--ignore-scripts"
               system "npm", "run", "build"
-              bin.install "bin/st-k8s"
-              prefix.install_metafiles
+              libexec.install Dir["*"]
+              libexec.install ".next"
+              bin.install_symlink libexec/"bin/st-k8s"
             end
           
             test do

--- a/bin/st-k8s
+++ b/bin/st-k8s
@@ -22,7 +22,7 @@ function printBanner() {
 }
 
 function run(cmd, args) {
-  const res = spawnSync(cmd, args, { stdio: 'inherit' });
+  const res = spawnSync(cmd, args, { stdio: 'inherit', cwd: root });
   if (res.error) {
     console.error(res.error);
     process.exit(1);
@@ -30,7 +30,7 @@ function run(cmd, args) {
   if (res.status !== 0) process.exit(res.status || 1);
 }
 
-const root = process.cwd();
+const root = path.join(__dirname, '..');
 const standaloneServer = path.join(root, '.next', 'standalone', 'server.js');
 
 // Print banner on launch


### PR DESCRIPTION
Fixes the st-k8s binary not finding `.next` and `package.json` out-of-the-box when installed from brew by correctly using `__dirname` instead of `process.cwd()`. Also fixes the release formula to correctly bundle `.next` directly within `libexec`.