### PR TITLE
feat: add automatic release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+        - feat
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📖 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+    - title: 🛠 Maintenance
+      labels:
+        - maintenance
+        - chore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           files: ${{ env.TARBALL_NAME }}
           draft: false
           prerelease: false
+          generate_release_notes: true
 
       - name: Update Homebrew tap formula
         env:


### PR DESCRIPTION
This PR enables automatically generated release notes for the GitHub Release workflow.

### Changes:
- Added `.github/release.yml` to configure change categories (Features, Bug Fixes, etc.).
- Updated `.github/workflows/release.yml` to set `generate_release_notes: true` in the `softprops/action-gh-release` step.

When a new version tag is pushed, GitHub will now automatically generate a summary of changes based on merged PRs and commits.