### PR TITLE
feat: Improve JSON rendering in resource tables (#97)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest",
+    "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "mcp": "tsx src/mcp-server.ts",

--- a/src/app/k8s-dashboard/DashboardContent.tsx
+++ b/src/app/k8s-dashboard/DashboardContent.tsx
@@ -7,6 +7,7 @@ import { ToolType } from "./Sidebar";
 import { Grid, List, Download, Zap, XCircle, MessageSquarePlus } from "lucide-react";
 import { MetricsDashboard } from "@/components/MetricsCharts";
 import { useChat } from "@/components/ChatContext";
+import { JsonRenderer } from "@/components/JsonRenderer";
 import { RefreshSelector } from "@/components/RefreshSelector";
 import { useRefresh } from "@/lib/refresh-context";
 import { toast } from "sonner";
@@ -384,7 +385,7 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
         const val = info.getValue();
         if (typeof val === "object" && val !== null) {
           if (Object.keys(val).length === 0) return "";
-          return JSON.stringify(val);
+          return <JsonRenderer value={val} label={key} />;
         }
         if (key === 'status' || key === 'phase') {
           const status = String(val);
@@ -572,16 +573,21 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
           <TableBody>
             {table.getRowModel().rows.map((row) => (
               <TableRow key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell
-                    key={cell.id}
-                    className="truncate max-w-[200px]"
-                    title={String(cell.getValue())}
-                    style={{ width: cell.column.getSize() }}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
+                {row.getVisibleCells().map((cell) => {
+                  const val = cell.getValue();
+                  const isObject = typeof val === "object" && val !== null;
+                  
+                  return (
+                    <TableCell
+                      key={cell.id}
+                      className={isObject ? "" : "truncate max-w-[200px]"}
+                      title={isObject ? undefined : String(val)}
+                      style={{ width: cell.column.getSize() }}
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  );
+                })}
               </TableRow>
             ))}
           </TableBody>
@@ -660,10 +666,10 @@ function ResourceCard({ item, tool }: { item: Record<string, unknown>, tool?: st
   const { addAttachment } = useChat();
 
   // Helper to render object properties
-  const renderValue = (val: unknown) => {
+  const renderValue = (val: unknown, key?: string) => {
     if (typeof val === "object" && val !== null) {
       if (Object.keys(val).length === 0) return "";
-      return JSON.stringify(val);
+      return <JsonRenderer value={val} label={key} maxItems={1} />;
     }
     return String(val);
   };
@@ -704,8 +710,8 @@ function ResourceCard({ item, tool }: { item: Record<string, unknown>, tool?: st
             return (
               <div key={key} className="flex justify-between border-b pb-1 last:border-0 last:pb-0">
                 <span className="font-medium text-zinc-500 capitalize px-1">{key}</span>
-                <span className="text-right truncate max-w-[150px]" title={String(value)}>
-                  {renderValue(value)}
+                <span className="text-right truncate max-w-[150px]" title={typeof value === 'object' ? undefined : String(value)}>
+                  {renderValue(value, key)}
                 </span>
               </div>
             );

--- a/src/app/k8s-dashboard/Footer.tsx
+++ b/src/app/k8s-dashboard/Footer.tsx
@@ -54,13 +54,18 @@ export default function Footer({
   const [versionInfo, setVersionInfo] = useState<{ version: string; latestVersion: string | null; updateAvailable: boolean } | null>(null);
 
   useEffect(() => {
-    const url = new URL("/api/config", window.location.origin);
-    fetch(url.toString())
+    // Helper to fetch with absolute URL for test environments
+    const safeFetch = (path: string) => {
+      const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
+      return fetch(new URL(path, baseUrl).toString());
+    };
+
+    safeFetch("/api/config")
       .then((res) => res.json())
       .then((data) => setProjectPath(data.projectPath || ""))
       .catch(console.error);
 
-    fetch("/api/version")
+    safeFetch("/api/version")
       .then((res) => res.json())
       .then((data) => setVersionInfo(data))
       .catch(console.error);

--- a/src/app/k8s-dashboard/__tests__/Footer.test.tsx
+++ b/src/app/k8s-dashboard/__tests__/Footer.test.tsx
@@ -1,6 +1,6 @@
 
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Footer from '../Footer'
 
 describe('Footer', () => {
@@ -14,6 +14,19 @@ describe('Footer', () => {
     isLoadingNamespaces: false,
     isLoadingContexts: false
   }
+
+  beforeEach(() => {
+    // Provide a default mock for fetch to avoid errors in tests that don't mock it explicitly
+    global.fetch = vi.fn().mockImplementation(() => 
+      Promise.resolve({
+        json: () => Promise.resolve({})
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   it('renders fixed text elements', () => {
     render(<Footer {...defaultProps} />)
@@ -44,7 +57,7 @@ describe('Footer', () => {
 
   it('renders current version', async () => {
     const mockFetch = vi.fn().mockImplementation((url) => {
-      if (url === '/api/version') {
+      if (url.includes('/api/version')) {
         return Promise.resolve({
           json: () => Promise.resolve({ version: '1.0.0', latestVersion: '1.0.0', updateAvailable: false })
         })
@@ -55,12 +68,11 @@ describe('Footer', () => {
 
     render(<Footer {...defaultProps} />)
     expect(await screen.findByText('v1.0.0')).toBeDefined()
-    global.fetch = vi.restoreAllMocks as any
   })
 
   it('renders update available badge', async () => {
     const mockFetch = vi.fn().mockImplementation((url) => {
-      if (url === '/api/version') {
+      if (url.includes('/api/version')) {
         return Promise.resolve({
           json: () => Promise.resolve({ version: '1.0.0', latestVersion: '1.1.0', updateAvailable: true })
         })
@@ -71,6 +83,5 @@ describe('Footer', () => {
 
     render(<Footer {...defaultProps} />)
     expect(await screen.findByText('↑ v1.1.0')).toBeDefined()
-    global.fetch = vi.restoreAllMocks as any
   })
 })

--- a/src/components/JsonRenderer.tsx
+++ b/src/components/JsonRenderer.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Maximize2, ExternalLink, Copy, Check } from "lucide-react";
+
+interface JsonRendererProps {
+  value: unknown;
+  label?: string;
+  maxItems?: number;
+}
+
+export function JsonRenderer({ value, label, maxItems = 2 }: JsonRendererProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  if (value === null || value === undefined) return null;
+
+  if (typeof value !== "object") {
+    return <span className="text-sm">{String(value)}</span>;
+  }
+
+  if (Object.keys(value as object).length === 0) return null;
+
+  const isArray = Array.isArray(value);
+  const entries = isArray ? (value as any[]) : Object.entries(value as object);
+  const totalCount = entries.length;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(value, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy JSON:", err);
+    }
+  };
+
+  // Helper to render inline items
+  const renderInline = () => {
+    if (isArray) {
+      if (totalCount === 0) return null;
+      if (typeof entries[0] !== 'object') {
+        return (
+          <div className="flex flex-wrap gap-1">
+            {entries.slice(0, maxItems).map((v, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-secondary text-secondary-foreground border border-border"
+              >
+                {String(v)}
+              </span>
+            ))}
+            {totalCount > maxItems && (
+              <span className="text-[10px] text-muted-foreground">+{totalCount - maxItems} more</span>
+            )}
+          </div>
+        );
+      }
+    } else {
+      const items = entries as [string, any][];
+      // Only render small flat objects inline
+      const isFlat = items.every(([_, v]) => typeof v !== 'object' || v === null);
+      
+      if (isFlat && totalCount <= maxItems) {
+        return (
+          <div className="flex flex-wrap gap-1">
+            {items.map(([k, v], i) => (
+              <span
+                key={i}
+                className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-zinc-100 dark:bg-zinc-800 text-zinc-800 dark:text-zinc-200 border border-zinc-200 dark:border-zinc-700 max-w-[150px] truncate"
+                title={`${k}: ${String(v)}`}
+              >
+                <span className="opacity-70 mr-1">{k}:</span> {String(v)}
+              </span>
+            ))}
+          </div>
+        );
+      }
+    }
+    
+    return (
+      <span className="text-[11px] text-muted-foreground font-medium">
+        {isArray ? `${totalCount} items` : `${totalCount} keys`}
+      </span>
+    );
+  };
+
+  return (
+    <div className="flex items-center gap-2 group">
+      <div className="flex-1 overflow-hidden">
+        {renderInline()}
+      </div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button 
+            variant="ghost" 
+            size="icon" 
+            className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+            title="View full details"
+          >
+            <Maximize2 className="h-3.5 w-3.5" />
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col p-0">
+          <DialogHeader className="p-6 pb-2">
+            <div className="flex items-center justify-between mr-8">
+              <DialogTitle className="text-xl font-bold flex items-center gap-2 capitalize">
+                {label?.replace(/([A-Z])/g, ' $1').trim() || "Resource Details"}
+              </DialogTitle>
+              <div className="flex items-center gap-2">
+                <Button 
+                  variant="outline" 
+                  size="sm" 
+                  className="h-8 gap-1.5"
+                  onClick={handleCopy}
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-3.5 w-3.5 text-green-500" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-3.5 w-3.5" />
+                      Copy JSON
+                    </>
+                  )}
+                </Button>
+                <Button 
+                  variant="outline" 
+                  size="sm" 
+                  className="h-8 gap-1.5 text-muted-foreground"
+                  onClick={() => {
+                    const blob = new Blob([JSON.stringify(value, null, 2)], { type: 'application/json' });
+                    const url = URL.createObjectURL(blob);
+                    window.open(url, '_blank');
+                  }}
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Raw JSON
+                </Button>
+              </div>
+            </div>
+          </DialogHeader>
+          <div className="flex-1 overflow-auto p-6 bg-zinc-50 dark:bg-zinc-950/50">
+            <div className="rounded-lg border bg-background overflow-hidden">
+                <pre className="p-6 text-xs font-mono leading-relaxed overflow-x-auto text-foreground dark:text-zinc-300">
+                  {JSON.stringify(value, null, 2)}
+                </pre>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/__tests__/ChatContext.test.tsx
+++ b/src/components/__tests__/ChatContext.test.tsx
@@ -45,21 +45,16 @@ const TestComponent = () => {
 // Tests
 // ----------------------------------------------------------------
 describe('ChatProvider', () => {
-    let store: Record<string, string>;
-
     beforeEach(() => {
         vi.clearAllMocks();
-        store = {};
-        vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => store[key] ?? null);
-        vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key, value) => { store[key] = value; });
-        vi.spyOn(Storage.prototype, 'removeItem').mockImplementation((key) => { delete store[key]; });
+        localStorage.clear();
     });
 
     // ---- attachments (backwards-compatible) ----
 
     it('loads initial attachments from localStorage', () => {
         const initialData = [{ id: '1', name: 'saved-res', type: 'pod', data: {} }];
-        store['chat_attachments'] = JSON.stringify(initialData);
+        localStorage.setItem('chat_attachments', JSON.stringify(initialData));
 
         render(<ChatProvider><TestComponent /></ChatProvider>);
 
@@ -196,7 +191,7 @@ describe('ChatProvider', () => {
             messages: [{ role: 'user', content: 'hi' }],
             attachments: [],
         };
-        store['chat_sessions'] = JSON.stringify([session]);
+        localStorage.setItem('chat_sessions', JSON.stringify([session]));
 
         render(<ChatProvider><TestComponent /></ChatProvider>);
 

--- a/src/components/__tests__/JsonRenderer.test.tsx
+++ b/src/components/__tests__/JsonRenderer.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { JsonRenderer } from '../JsonRenderer';
+import React from 'react';
+
+// Mock clipboard
+const mockClipboard = {
+  writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+};
+Object.defineProperty(navigator, 'clipboard', {
+  value: mockClipboard,
+  writable: true,
+});
+
+describe('JsonRenderer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders flat objects as badges', () => {
+    const data = { status: 'Running', type: 'Pod' };
+    render(<JsonRenderer value={data} label="Test Object" />);
+    
+    expect(screen.getByText('status:')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getByText('type:')).toBeInTheDocument();
+    expect(screen.getByText('Pod')).toBeInTheDocument();
+  });
+
+  it('renders summary for nested objects', () => {
+    const data = { metadata: { name: 'test' }, spec: { replicas: 1 } };
+    render(<JsonRenderer value={data} label="Test Nest" />);
+    
+    expect(screen.getByText('2 keys')).toBeInTheDocument();
+  });
+
+  it('opens modal and allows copying JSON', async () => {
+    const data = { foo: 'bar' };
+    render(<JsonRenderer value={data} label="TestCopy" />);
+    
+    // Hover and click expand button
+    const expandBtn = screen.getByTitle('View full details');
+    fireEvent.click(expandBtn);
+    
+    // Check if modal is open
+    expect(screen.getByText('Test Copy')).toBeInTheDocument();
+    
+    // Click copy button
+    const copyBtn = screen.getByText('Copy JSON');
+    fireEvent.click(copyBtn);
+    
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+    expect(await screen.findByText('Copied')).toBeInTheDocument();
+    
+    // Check if it reverts back
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 2100));
+    });
+    
+    expect(await screen.findByText('Copy JSON')).toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/k8s.test.ts
+++ b/src/lib/__tests__/k8s.test.ts
@@ -224,6 +224,8 @@ describe('k8s library', () => {
         memoryCapacity: '16Gi',
         arch: 'amd64',
         os: 'linux',
+        labels: { 'node-role.kubernetes.io/control-plane': '' },
+        conditions: [{ type: 'Ready', status: 'True' }],
         created: '2023-01-01T00:00:00Z'
       })
       expect(mocks.coreApi.listNode).toHaveBeenCalled()
@@ -272,6 +274,7 @@ describe('k8s library', () => {
         clusterIP: '10.0.0.1',
         ports: [{ port: 80 }],
         selector: { app: 'web' },
+        labels: {},
         created: '2023-01-01T00:00:00Z'
       })
       expect(mocks.coreApi.listNamespacedService).toHaveBeenCalledWith({ namespace: 'default' })
@@ -296,6 +299,7 @@ describe('k8s library', () => {
         current: 3,
         ready: 3,
         available: 3,
+        labels: {},
         created: '2023-01-01T00:00:00Z'
       })
       expect(mocks.appsApi.listNamespacedDaemonSet).toHaveBeenCalledWith({ namespace: 'default' })
@@ -320,6 +324,7 @@ describe('k8s library', () => {
         replicas: 3,
         ready: 3,
         available: 3,
+        labels: {},
         created: '2023-01-01T00:00:00Z'
       })
       expect(mocks.appsApi.listNamespacedReplicaSet).toHaveBeenCalledWith({ namespace: 'default' })
@@ -343,6 +348,7 @@ describe('k8s library', () => {
         name: 'sts-1',
         replicas: 2,
         ready: 2,
+        labels: {},
         created: '2023-01-01T00:00:00Z'
       })
       expect(mocks.appsApi.listNamespacedStatefulSet).toHaveBeenCalledWith({ namespace: 'default' })

--- a/src/lib/__tests__/refresh-context.test.tsx
+++ b/src/lib/__tests__/refresh-context.test.tsx
@@ -21,10 +21,7 @@ const TestComponent = () => {
 describe('RefreshProvider', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // Mock localStorage
-        const store: Record<string, string> = {};
-        vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => store[key] || null);
-        vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key, value) => { store[key] = value; });
+        localStorage.clear();
     });
 
     it('loads initial state from localStorage', () => {

--- a/src/lib/k8s.ts
+++ b/src/lib/k8s.ts
@@ -108,7 +108,9 @@ export async function getPods(namespace: string, context?: string) {
         cpuLimit: resources.limits?.cpu || "-",
         memoryRequest: resources.requests?.memory || "-",
         memoryLimit: resources.limits?.memory || "-",
-        status: pod.status?.phase
+        status: pod.status?.phase,
+        labels: pod.metadata?.labels || {},
+        nodeName: pod.spec?.nodeName,
       };
     })
   );
@@ -123,6 +125,8 @@ export async function getDeployments(namespace: string, context?: string) {
     readyReplicas: item.status?.readyReplicas || 0,
     updatedReplicas: item.status?.updatedReplicas || 0,
     availableReplicas: item.status?.availableReplicas || 0,
+    labels: item.metadata?.labels || {},
+    annotations: item.metadata?.annotations || {},
     created: item.metadata?.creationTimestamp,
   }));
 }
@@ -136,6 +140,7 @@ export async function getServices(namespace: string, context?: string) {
     clusterIP: item.spec?.clusterIP,
     ports: item.spec?.ports || [],
     selector: item.spec?.selector,
+    labels: item.metadata?.labels || {},
     created: item.metadata?.creationTimestamp,
   }));
 }
@@ -149,6 +154,7 @@ export async function getDaemonSets(namespace: string, context?: string) {
     current: item.status?.currentNumberScheduled || 0,
     ready: item.status?.numberReady || 0,
     available: item.status?.numberAvailable || 0,
+    labels: item.metadata?.labels || {},
     created: item.metadata?.creationTimestamp,
   }));
 }
@@ -161,6 +167,7 @@ export async function getReplicaSets(namespace: string, context?: string) {
     replicas: item.spec?.replicas || 0,
     ready: item.status?.readyReplicas || 0,
     available: item.status?.availableReplicas || 0,
+    labels: item.metadata?.labels || {},
     created: item.metadata?.creationTimestamp,
   }));
 }
@@ -172,6 +179,7 @@ export async function getStatefulSets(namespace: string, context?: string) {
     name: item.metadata?.name,
     replicas: item.spec?.replicas || 0,
     ready: item.status?.readyReplicas || 0,
+    labels: item.metadata?.labels || {},
     created: item.metadata?.creationTimestamp,
   }));
 }
@@ -253,6 +261,8 @@ export async function getNodes(context?: string) {
       memoryCapacity: node.status?.capacity?.memory,
       arch: node.status?.nodeInfo?.architecture,
       os: node.status?.nodeInfo?.operatingSystem,
+      labels: labels,
+      conditions: node.status?.conditions || [],
       created: node.metadata?.creationTimestamp,
     };
   });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,8 +1,74 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 
+/**
+ * Robust mock for localStorage and sessionStorage.
+ * This handles environments where window might be missing (Node)
+ * or where JSDOM's localStorage is incomplete or read-only.
+ */
+const createStorageMock = () => {
+    let store: Record<string, string> = {};
+    return {
+        getItem: vi.fn((key: string) => store[key] || null),
+        setItem: vi.fn((key: string, value: string) => {
+            store[key] = value ? value.toString() : '';
+        }),
+        removeItem: vi.fn((key: string) => {
+            delete store[key];
+        }),
+        clear: vi.fn(() => {
+            store = {};
+        }),
+        key: vi.fn((index: number) => Object.keys(store)[index] || null),
+        get length() {
+            return Object.keys(store).length;
+        },
+    };
+};
+
+const mockStorage = createStorageMock();
+
+if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'localStorage', { value: mockStorage });
+    Object.defineProperty(window, 'sessionStorage', { value: mockStorage });
+} else {
+    vi.stubGlobal('localStorage', mockStorage);
+    vi.stubGlobal('sessionStorage', mockStorage);
+}
+
+// Cleanup after each test
 afterEach(() => {
-  cleanup()
-})
+    cleanup();
+    vi.clearAllMocks();
+    mockStorage.clear();
+});
+
+// Global mocks for Next.js
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({
+        push: vi.fn(),
+        replace: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    useSearchParams: () => ({
+        get: vi.fn(),
+    }),
+    usePathname: () => '',
+}));
+
+// Mock ResizeObserver
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+}));
+
+// Mock fetch
+global.fetch = vi.fn().mockImplementation(() =>
+    Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+    })
+);
 


### PR DESCRIPTION
Resolves issue #97.

### Changes Included:

1. **New `JsonRenderer` Component**:
   - Renders small/flat objects (like labels) as compact badges.
   - Renders complex objects/arrays as a "View Details" button.
   - Expandable modal with code-formatted JSON viewing.
   - **Feature**: Copy raw JSON to clipboard from the modal.
   - **Feature**: View raw JSON in a new browser tab.

2. **Expanded K8s Metadata**:
   - Updated `k8s.ts` to include `labels`, `annotations`, and `conditions` for Pods, Nodes, Deployments, and more.
   - This provides much more depth in the dashboard views.

3. **Infrastructure & Tests**:
   - Fixed `localStorage` mocking in `vitest.setup.ts` to be more robust across Node and JSDOM environments.
   - Resolved `Invalid URL` errors in tests by introducing a `safeFetch` helper in `Footer.tsx`.
   - Updated snapshots and unit tests for the K8s library and context providers.
   - Added full unit tests for the new `JsonRenderer` component.

### Screenshots/Demo:
The table now shows compact badges for labels and an "Expand" icon for large fields like Annotations or Status Conditions. Clicking the expand icon opens a modal with a formatted JSON block and a Copy button.

Verified with `npm test` (all 124 tests passing).