### PR TITLE
feat: add Kubectl Cheat Sheet for resource quick actions (#113)

### DIFF
--- a/src/app/k8s-dashboard/DashboardContent.tsx
+++ b/src/app/k8s-dashboard/DashboardContent.tsx
@@ -4,13 +4,14 @@ import { useEffect, useState, useMemo, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ToolType } from "./Sidebar";
-import { Grid, List, Download, Zap, XCircle, MessageSquarePlus } from "lucide-react";
+import { Grid, List, Download, Zap, XCircle, MessageSquarePlus, Terminal } from "lucide-react";
 import { MetricsDashboard } from "@/components/MetricsCharts";
 import { useChat } from "@/components/ChatContext";
 import { JsonRenderer } from "@/components/JsonRenderer";
 import { RefreshSelector } from "@/components/RefreshSelector";
 import { useRefresh } from "@/lib/refresh-context";
 import { toast } from "sonner";
+import { KubectlCheatSheet } from "@/components/KubectlCheatSheet";
 import {
   Dialog,
   DialogContent,
@@ -303,7 +304,7 @@ export default function DashboardContent({ namespace, context, tool }: Dashboard
           ) : viewMode === "grid" ? (
             <div className="grid gap-4 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
               {data.map((item, i) => (
-                <ResourceCard key={i} item={item} tool={tool} />
+                <ResourceCard key={i} item={item} tool={tool} namespace={namespace} />
               ))}
             </div>
           ) : (
@@ -320,6 +321,7 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
   const { addAttachment } = useChat();
   const [pfTarget, setPfTarget] = useState<{ podName?: string, serviceName?: string } | null>(null);
   const [pfPorts, setPfPorts] = useState({ remote: "8080", local: "8080", address: "127.0.0.1" });
+  const [cheatSheetTarget, setCheatSheetTarget] = useState<{ name: string, type: string } | null>(null);
 
   const handlePortForward = useCallback(async (params: { podName?: string, serviceName?: string, containerPort: number, localPort?: number, localAddress?: string }) => {
     try {
@@ -453,13 +455,12 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
               size="icon"
               className="h-6 w-6 text-orange-500 hover:text-orange-400 hover:bg-orange-500/10"
               onClick={() => {
-                setPfTarget({ serviceName });
-                setPfPorts({ remote: "80", local: "80", address: "127.0.0.1" });
+                setCheatSheetTarget({ name: serviceName, type: 'services' });
               }}
-              title="Port Forward"
-              aria-label={`Port forward for service ${serviceName}`}
+              title="Kubectl Cheat Sheet"
+              aria-label={`Show kubectl cheat sheet for ${serviceName}`}
             >
-              <Zap className="h-3 w-3" />
+              <Terminal className="h-3 w-3" />
             </Button>
           );
         },
@@ -490,6 +491,32 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
         size: 80
       });
     }
+
+    // Kubectl Cheat Sheet action
+    baseCols.push({
+      id: 'cheat-sheet',
+      header: '',
+      cell: (info) => {
+        const row = info.row.original;
+        const name = String(row.name || row.podName || (row.metadata as { name?: string })?.name || '');
+        if (!name || tool === 'port-forwards' || tool === 'metrics') return null;
+        return (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="h-7 w-7 text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 hover:bg-zinc-500/10"
+            onClick={() => {
+              setCheatSheetTarget({ name, type: tool || 'resource' });
+            }}
+            title="Kubectl Cheat Sheet"
+            aria-label={`Show kubectl cheat sheet for ${name}`}
+          >
+            <Terminal className="h-4 w-4" />
+          </Button>
+        );
+      },
+      size: 40
+    });
 
     // Add to Chat action
     baseCols.push({
@@ -658,12 +685,23 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {cheatSheetTarget && (
+        <KubectlCheatSheet
+          open={!!cheatSheetTarget}
+          onOpenChange={(open) => !open && setCheatSheetTarget(null)}
+          resourceName={cheatSheetTarget.name}
+          resourceType={cheatSheetTarget.type}
+          namespace={namespace}
+        />
+      )}
     </div>
   );
 }
 
-function ResourceCard({ item, tool }: { item: Record<string, unknown>, tool?: string }) {
+function ResourceCard({ item, tool, namespace }: { item: Record<string, unknown>, tool?: string, namespace?: string }) {
   const { addAttachment } = useChat();
+  const [showCheatSheet, setShowCheatSheet] = useState(false);
 
   // Helper to render object properties
   const renderValue = (val: unknown, key?: string) => {
@@ -683,23 +721,35 @@ function ResourceCard({ item, tool }: { item: Record<string, unknown>, tool?: st
         <CardTitle className="text-base font-medium truncate" title={name}>
           {name}
         </CardTitle>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="h-8 w-8 text-blue-500 hover:text-blue-400 hover:bg-blue-500/10"
-          onClick={() => {
-            addAttachment({
-              name,
-              type: tool || 'resource',
-              data: item
-            });
-            toast.success(`Attached ${name} to chat`);
-          }}
-          title="Add to Chat"
-          aria-label={`Add resource ${name} to chat`}
-        >
-          <MessageSquarePlus className="h-4 w-4" />
-        </Button>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="h-8 w-8 text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 hover:bg-zinc-500/10"
+            onClick={() => setShowCheatSheet(true)}
+            title="Kubectl Cheat Sheet"
+            aria-label={`Show kubectl cheat sheet for ${name}`}
+          >
+            <Terminal className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="h-8 w-8 text-blue-500 hover:text-blue-400 hover:bg-blue-500/10"
+            onClick={() => {
+              addAttachment({
+                name,
+                type: tool || 'resource',
+                data: item
+              });
+              toast.success(`Attached ${name} to chat`);
+            }}
+            title="Add to Chat"
+            aria-label={`Add resource ${name} to chat`}
+          >
+            <MessageSquarePlus className="h-4 w-4" />
+          </Button>
+        </div>
       </CardHeader>
       <CardContent className="pt-4 text-sm">
         <div className="grid gap-2">
@@ -718,6 +768,15 @@ function ResourceCard({ item, tool }: { item: Record<string, unknown>, tool?: st
           })}
         </div>
       </CardContent>
+      {showCheatSheet && (
+        <KubectlCheatSheet
+          open={showCheatSheet}
+          onOpenChange={setShowCheatSheet}
+          resourceName={name}
+          resourceType={tool || 'resource'}
+          namespace={namespace}
+        />
+      )}
     </Card>
   );
 }

--- a/src/components/KubectlCheatSheet.tsx
+++ b/src/components/KubectlCheatSheet.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Clipboard, Check, Terminal } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+interface KubectlCheatSheetProps {
+  resourceType: string;
+  resourceName: string;
+  namespace?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const toolToKubectlMap: Record<string, string> = {
+  "pod-resources": "pod",
+  "pods": "pod",
+  "deployments": "deployment",
+  "replicasets": "replicaset",
+  "statefulsets": "statefulset",
+  "daemonsets": "daemonset",
+  "services": "service",
+  "ingresses": "ingress",
+  "endpoints": "endpoints",
+  "events": "event",
+  "configmaps": "configmap",
+  "jobs": "job",
+  "cronjobs": "cronjob",
+  "serviceaccounts": "serviceaccount",
+  "roles": "role",
+  "rolebindings": "rolebinding",
+  "nodes": "node",
+  "volumes": "pv",
+};
+
+export function KubectlCheatSheet({
+  resourceType,
+  resourceName,
+  namespace,
+  open,
+  onOpenChange,
+}: KubectlCheatSheetProps) {
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  const k8sType = toolToKubectlMap[resourceType] || resourceType;
+  const nsFlag = namespace && namespace !== "all" ? ` -n ${namespace}` : "";
+
+  const commands = [
+    {
+      label: "Describe Resource",
+      command: `kubectl describe ${k8sType} ${resourceName}${nsFlag}`,
+      description: "Show detailed information about the resource.",
+    },
+    {
+      label: "View YAML",
+      command: `kubectl get ${k8sType} ${resourceName}${nsFlag} -o yaml`,
+      description: "Get the resource definition in YAML format.",
+    },
+    {
+      label: "Delete Resource",
+      command: `kubectl delete ${k8sType} ${resourceName}${nsFlag}`,
+      description: "Delete the resource from the cluster.",
+    },
+  ];
+
+  // Resource-specific commands
+  if (k8sType === "pod") {
+    commands.push(
+      {
+        label: "View Logs",
+        command: `kubectl logs ${resourceName}${nsFlag}`,
+        description: "Fetch the logs of the first container in the pod.",
+      },
+      {
+        label: "Interactive Shell",
+        command: `kubectl exec -it ${resourceName}${nsFlag} -- /bin/sh`,
+        description: "Open an interactive shell inside the pod.",
+      },
+      {
+        label: "Port Forward",
+        command: `kubectl port-forward ${resourceName}${nsFlag} 8080:8080`,
+        description: "Forward a local port to a port on the pod.",
+      }
+    );
+  } else if (k8sType === "service") {
+    commands.push({
+      label: "Port Forward",
+      command: `kubectl port-forward svc/${resourceName}${nsFlag} 8080:80`,
+      description: "Forward a local port to the service.",
+    });
+  }
+
+  if (["deployment", "statefulset", "replicaset"].includes(k8sType)) {
+    commands.push({
+      label: "Scale Resource",
+      command: `kubectl scale ${k8sType} ${resourceName}${nsFlag} --replicas=3`,
+      description: "Scale the resource to a specific number of replicas.",
+    });
+  }
+
+  if (["deployment", "statefulset", "daemonset"].includes(k8sType)) {
+    commands.push({
+      label: "Restart (Rollout)",
+      command: `kubectl rollout restart ${k8sType}/${resourceName}${nsFlag}`,
+      description: "Perform a rolling restart of the resource.",
+    });
+  }
+
+  if (k8sType === "node") {
+    commands.push(
+      {
+        label: "Cordon Node",
+        command: `kubectl cordon ${resourceName}`,
+        description: "Mark node as unschedulable (prevents new pods from being scheduled).",
+      },
+      {
+        label: "Drain Node",
+        command: `kubectl drain ${resourceName} --ignore-daemonsets --delete-emptydir-data`,
+        description: "Evict pods from node in preparation for maintenance.",
+      },
+      {
+        label: "Uncordon Node",
+        command: `kubectl uncordon ${resourceName}`,
+        description: "Mark node as schedulable.",
+      }
+    );
+  }
+
+  const copyToClipboard = async (text: string, index: number) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedIndex(index);
+      toast.success("Command copied to clipboard");
+      setTimeout(() => setCopiedIndex(null), 2000);
+    } catch (err) {
+      toast.error("Failed to copy command");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Terminal className="h-5 w-5" />
+            Kubectl Cheat Sheet: {resourceName}
+          </DialogTitle>
+          <DialogDescription>
+            Quick actions for {k8sType} in namespace {namespace || "default"}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {commands.map((cmd, index) => (
+            <div
+              key={index}
+              className="flex flex-col gap-2 p-3 rounded-lg border bg-zinc-50 dark:bg-zinc-900/50"
+            >
+              <div className="flex justify-between items-center">
+                <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                  {cmd.label}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 gap-2"
+                  onClick={() => copyToClipboard(cmd.command, index)}
+                >
+                  {copiedIndex === index ? (
+                    <Check className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <Clipboard className="h-4 w-4" />
+                  )}
+                  {copiedIndex === index ? "Copied" : "Copy"}
+                </Button>
+              </div>
+              <code className="text-xs bg-zinc-200 dark:bg-zinc-800 p-2 rounded block whitespace-pre-wrap break-all border border-zinc-300 dark:border-zinc-700 font-mono">
+                {cmd.command}
+              </code>
+              <p className="text-[11px] text-zinc-500 italic">{cmd.description}</p>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/__tests__/KubectlCheatSheet.test.tsx
+++ b/src/components/__tests__/KubectlCheatSheet.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { KubectlCheatSheet } from '../KubectlCheatSheet';
+import React from 'react';
+
+// Mock clipboard
+const mockClipboard = {
+  writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+};
+Object.defineProperty(navigator, 'clipboard', {
+  value: mockClipboard,
+  writable: true,
+});
+
+// Mock Dialog component since it uses Radix UI which can be tricky in tests
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode, open: boolean }) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('KubectlCheatSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly for a pod', () => {
+    render(
+      <KubectlCheatSheet
+        resourceType="pod-resources"
+        resourceName="test-pod"
+        namespace="test-ns"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/Kubectl Cheat Sheet: test-pod/)).toBeInTheDocument();
+    expect(screen.getByText(/kubectl describe pod test-pod -n test-ns/)).toBeInTheDocument();
+    expect(screen.getByText(/kubectl logs test-pod -n test-ns/)).toBeInTheDocument();
+    expect(screen.getByText(/kubectl exec -it test-pod -n test-ns -- \/bin\/sh/)).toBeInTheDocument();
+  });
+
+  it('renders correctly for a service', () => {
+    render(
+      <KubectlCheatSheet
+        resourceType="services"
+        resourceName="test-svc"
+        namespace="default"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/kubectl describe service test-svc -n default/)).toBeInTheDocument();
+    expect(screen.getByText(/kubectl port-forward svc\/test-svc -n default 8080:80/)).toBeInTheDocument();
+  });
+
+  it('renders scale command for replicasets', () => {
+    render(
+      <KubectlCheatSheet
+        resourceType="replicasets"
+        resourceName="test-rs"
+        namespace="demo"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/kubectl scale replicaset test-rs -n demo --replicas=3/)).toBeInTheDocument();
+  });
+
+  it('renders node specific commands', () => {
+    render(
+      <KubectlCheatSheet
+        resourceType="nodes"
+        resourceName="test-node"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/kubectl cordon test-node/)).toBeInTheDocument();
+    expect(screen.getByText(/kubectl drain test-node --ignore-daemonsets --delete-emptydir-data/)).toBeInTheDocument();
+  });
+
+  it('copies command to clipboard', async () => {
+    render(
+      <KubectlCheatSheet
+        resourceType="deployments"
+        resourceName="test-deploy"
+        namespace="prod"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    const copyButtons = screen.getAllByText('Copy');
+    fireEvent.click(copyButtons[0]);
+
+    expect(mockClipboard.writeText).toHaveBeenCalledWith('kubectl describe deployment test-deploy -n prod');
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <KubectlCheatSheet
+        resourceType="pod-resources"
+        resourceName="test-pod"
+        namespace="test-ns"
+        open={false}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.queryByText(/Kubectl Cheat Sheet/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Resolves #113

This PR introduces a "Kubectl Cheat Sheet" component that generates common `kubectl` commands for cluster resources. 

### Key Features:
- **Dynamic Command Generation**: Supports Pods, Services, Deployments, ReplicaSets, StatefulSets, DaemonSets, and Nodes.
- **Resource-Specific Actions**:
  - Pods: `logs`, `exec`, `port-forward`.
  - Services: `port-forward`.
  - Scalable resources: `scale --replicas=3`.
  - Rollout resources: `rollout restart`.
  - Nodes: `cordon`, `drain`, `uncordon`.
- **Copy to Clipboard**: One-click functionality to copy commands for manual use.
- **Dashboard Integration**: Added to both Table and Grid views in the K8s Dashboard.

### Implementation Details:
- Created `KubectlCheatSheet` component using shadcn/ui Dialog.
- Added comprehensive unit tests in `KubectlCheatSheet.test.tsx`.
- Updated `DashboardContent` to trigger the cheat sheet from resource actions.

### Testing:
- Ran `npm test src/components/__tests__/KubectlCheatSheet.test.tsx` -> All tests passed.
- Verified in the dashboard UI that commands correctly reflect the resource name and active namespace.