### PR TITLE
feat: add granular release scripts (patch, minor, major)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "mcp": "tsx src/mcp-server.ts",
-    "release": "npm version patch -m \"chore(release): %s\" && git push --follow-tags"
+    "release": "npm run release:patch",
+    "release:patch": "npm version patch -m \"chore(release): %s\" && git push --follow-tags",
+    "release:minor": "npm version minor -m \"chore(release): %s\" && git push --follow-tags",
+    "release:major": "npm version major -m \"chore(release): %s\" && git push --follow-tags"
   },
   "dependencies": {
     "@github/copilot-sdk": "^0.1.21",


### PR DESCRIPTION
This PR updates `package.json` to include specific scripts for patch, minor, and major releases, allowing the user to choose the version bump type.

- `npm run release:patch` (aliased to `npm run release`)
- `npm run release:minor`
- `npm run release:major`

Each script handles the version bump, tagging, and pushing in one step.