### PR TITLE
Fix redundant cheat sheet icons and add Port Forward button for Services

### DIFF
--- a/src/app/k8s-dashboard/DashboardContent.tsx
+++ b/src/app/k8s-dashboard/DashboardContent.tsx
@@ -455,12 +455,13 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
               size="icon"
               className="h-6 w-6 text-orange-500 hover:text-orange-400 hover:bg-orange-500/10"
               onClick={() => {
-                setCheatSheetTarget({ name: serviceName, type: 'services' });
+                setPfTarget({ serviceName });
+                setPfPorts({ remote: "80", local: "8080", address: "127.0.0.1" });
               }}
-              title="Kubectl Cheat Sheet"
-              aria-label={`Show kubectl cheat sheet for ${serviceName}`}
+              title="Port Forward"
+              aria-label={`Port forward for service ${serviceName}`}
             >
-              <Terminal className="h-3 w-3" />
+              <Zap className="h-3 w-3" />
             </Button>
           );
         },


### PR DESCRIPTION
Resolves #118 

This PR addresses two UI issues in the services dashboard:
1. **Redundant Icons**: Removed the redundant "Kubectl Cheat Sheet" button from the service-specific `actions` column. The global cheat sheet icon remains functional and correctly positioned.
2. **Missing Port Forward**: Added the "Port Forward" (Zap icon) button to the service `actions` column, allowing users to initiate port-forwarding sessions for services directly from the dashboard.

The Port Forward dialog for services now defaults to remote port `80` and local port `8080`.

### Changes
- Updated `DashboardContent.tsx` to swap the terminal icon for the zap icon in the services action column.
- Added logic to handle service port-forwarding in the configuration dialog.