### PR TITLE
feat: consolidate multi-container pods on Pod Resources page (#119)

### DIFF
--- a/src/app/tools/k8s-pod-resources/page.tsx
+++ b/src/app/tools/k8s-pod-resources/page.tsx
@@ -1,13 +1,55 @@
 "use client";
 
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import useSWR from "swr";
 import Image from "next/image";
+import { ChevronRight, ChevronDown } from "lucide-react";
 import { RefreshSelector } from "@/components/RefreshSelector";
 import { useRefresh } from "@/lib/refresh-context";
 
 function fetcher(url: string) {
   return fetch(url).then((res) => res.json());
+}
+
+function parseCpu(cpu: string): number {
+  if (!cpu || cpu === '-') return 0;
+  if (cpu.endsWith('m')) return parseInt(cpu) / 1000;
+  return parseFloat(cpu);
+}
+
+function parseMemory(mem: string): number {
+  if (!mem || mem === '-') return 0;
+  const match = mem.match(/^([0-9.]+)([a-zA-Z]*)$/);
+  if (!match) return 0;
+  const value = parseFloat(match[1]);
+  const unit = match[2];
+  const multipliers: Record<string, number> = {
+    'Ki': 1024,
+    'Mi': 1024 * 1024,
+    'Gi': 1024 * 1024 * 1024,
+    'Ti': 1024 * 1024 * 1024 * 1024,
+    'K': 1000,
+    'M': 1000 * 1000,
+    'G': 1000 * 1000 * 1000,
+  };
+  return value * (multipliers[unit] || 1);
+}
+
+function formatCpu(value: number): string {
+  if (value === 0) return "-";
+  if (value < 1) return `${Math.round(value * 1000)}m`;
+  return `${value.toFixed(2)}`;
+}
+
+function formatMemory(value: number): string {
+  if (value === 0) return "-";
+  const units = ["B", "Ki", "Mi", "Gi", "Ti"];
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(1)}${units[unitIndex]}`;
 }
 
 interface PodResource {
@@ -21,49 +63,151 @@ interface PodResource {
 }
 
 function PodResourcesTable({ data, namespace }: { data: PodResource[], namespace: string }) {
+  const [expandedPods, setExpandedPods] = useState<Record<string, boolean>>({});
+
+  const togglePod = (podName: string) => {
+    setExpandedPods(prev => ({
+      ...prev,
+      [podName]: !prev[podName]
+    }));
+  };
+
+  // Group containers by pod
+  const podGroups = data.reduce((acc, curr) => {
+    if (!acc[curr.podName]) {
+      acc[curr.podName] = {
+        podName: curr.podName,
+        status: curr.status,
+        containers: [],
+        cpuReq: 0,
+        cpuLim: 0,
+        memReq: 0,
+        memLim: 0,
+      };
+    }
+    acc[curr.podName].containers.push(curr);
+    acc[curr.podName].cpuReq += parseCpu(curr.cpuRequest);
+    acc[curr.podName].cpuLim += parseCpu(curr.cpuLimit);
+    acc[curr.podName].memReq += parseMemory(curr.memoryRequest);
+    acc[curr.podName].memLim += parseMemory(curr.memoryLimit);
+    return acc;
+  }, {} as Record<string, {
+    podName: string;
+    status: string;
+    containers: PodResource[];
+    cpuReq: number;
+    cpuLim: number;
+    memReq: number;
+    memLim: number;
+  }>);
+
+  const sortedPodNames = Object.keys(podGroups).sort();
+
   return (
     <div className="w-full overflow-x-auto">
       <table className="min-w-full border border-zinc-200 dark:border-zinc-700">
         <thead>
           <tr className="bg-zinc-100 dark:bg-zinc-800">
-            <th className="px-4 py-2 text-left">Pod Name</th>
-            <th className="px-4 py-2 text-left">Container Name</th>
+            <th className="px-4 py-2 text-left w-10"></th>
+            <th className="px-4 py-2 text-left">Pod / Container Name</th>
             <th className="px-4 py-2 text-left">CPU Request</th>
             <th className="px-4 py-2 text-left">CPU Limit</th>
             <th className="px-4 py-2 text-left">Memory Request</th>
             <th className="px-4 py-2 text-left">Memory Limit</th>
-            <th className="px-4 py-2 text-left">Status</th>
-            <th className="px-4 py-2 text-left">Actions</th>
+            <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-zinc-500">Status</th>
+            <th className="px-4 py-2 text-left text-xs uppercase tracking-wider text-zinc-500">Actions</th>
           </tr>
         </thead>
-        <tbody>
-          {data.map((row, i) => (
-            <tr key={i} className="border-t border-zinc-200 dark:border-zinc-700 hover:bg-zinc-50 dark:hover:bg-zinc-800">
-              <td className="px-4 py-2 font-medium">{row.podName}</td>
-              <td className="px-4 py-2">{row.containerName}</td>
-              <td className="px-4 py-2 text-zinc-600 dark:text-zinc-400">{row.cpuRequest}</td>
-              <td className="px-4 py-2 text-zinc-600 dark:text-zinc-400">{row.cpuLimit}</td>
-              <td className="px-4 py-2 text-zinc-600 dark:text-zinc-400">{row.memoryRequest}</td>
-              <td className="px-4 py-2 text-zinc-600 dark:text-zinc-400">{row.memoryLimit}</td>
-              <td className="px-4 py-2">
-                <span className={`px-2 py-1 rounded text-xs font-bold ${
-                  row.status === 'Running' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
-                  row.status === 'Pending' ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' :
-                  'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-                }`}>
-                  {row.status}
-                </span>
-              </td>
-              <td className="px-4 py-2">
-                <a 
-                  href={`/tools/k8s-pod-logs?namespace=${namespace}&podName=${row.podName}&containerName=${row.containerName}`}
-                  className="text-blue-600 hover:underline dark:text-blue-400 text-sm font-semibold"
+        <tbody className="divide-y divide-zinc-200 dark:divide-zinc-700">
+          {sortedPodNames.map((podName) => {
+            const group = podGroups[podName];
+            const isExpanded = !!expandedPods[podName];
+            const hasMultipleContainers = group.containers.length > 1;
+
+            return (
+              <Fragment key={podName}>
+                {/* Pod Summary Row */}
+                <tr 
+                  className="bg-white dark:bg-zinc-900 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer transition-colors"
+                  onClick={() => togglePod(podName)}
                 >
-                  View Logs
-                </a>
-              </td>
-            </tr>
-          ))}
+                  <td className="px-4 py-3">
+                    {hasMultipleContainers && (
+                      isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-semibold text-blue-600 dark:text-blue-400">
+                    {podName} 
+                    {!hasMultipleContainers && (
+                      <span className="ml-2 text-xs font-normal text-zinc-500 italic">
+                        ({group.containers[0].containerName})
+                      </span>
+                    )}
+                    {hasMultipleContainers && (
+                      <span className="ml-2 text-xs font-normal text-zinc-400">
+                        {group.containers.length} containers
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-medium">{formatCpu(group.cpuReq)}</td>
+                  <td className="px-4 py-3 font-medium">{formatCpu(group.cpuLim)}</td>
+                  <td className="px-4 py-3 font-medium">{formatMemory(group.memReq)}</td>
+                  <td className="px-4 py-3 font-medium">{formatMemory(group.memLim)}</td>
+                  <td className="px-4 py-3">
+                    <span className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${
+                      group.status === 'Running' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
+                      group.status === 'Pending' ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' :
+                      'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                    }`}>
+                      {group.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    {!hasMultipleContainers && (
+                      <a 
+                        href={`/tools/k8s-pod-logs?namespace=${namespace}&podName=${podName}&containerName=${group.containers[0].containerName}`}
+                        className="text-xs text-blue-500 hover:underline"
+                        onClick={e => e.stopPropagation()}
+                      >
+                        Logs
+                      </a>
+                    )}
+                  </td>
+                </tr>
+
+                {/* Container Detail Rows */}
+                {isExpanded && group.containers.map((container, idx) => (
+                  <tr key={`${podName}-${container.containerName}-${idx}`} className="bg-zinc-50/50 dark:bg-zinc-800/20 border-l-4 border-l-blue-500/30">
+                    <td className="px-4 py-2 text-right text-zinc-400 text-xs">
+                    </td>
+                    <td className="px-4 py-2 pl-8 pb-3">
+                      <div className="flex flex-col">
+                        <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                          {container.containerName}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-2 text-sm text-zinc-500 dark:text-zinc-400">{container.cpuRequest}</td>
+                    <td className="px-4 py-2 text-sm text-zinc-500 dark:text-zinc-400">{container.cpuLimit}</td>
+                    <td className="px-4 py-2 text-sm text-zinc-500 dark:text-zinc-400">{container.memoryRequest}</td>
+                    <td className="px-4 py-2 text-sm text-zinc-500 dark:text-zinc-400">{container.memoryLimit}</td>
+                    <td className="px-4 py-2">
+                       {/* Container status if available, otherwise inherit pod status */}
+                    </td>
+                    <td className="px-4 py-2">
+                      <a 
+                        href={`/tools/k8s-pod-logs?namespace=${namespace}&podName=${podName}&containerName=${container.containerName}`}
+                        className="text-xs text-blue-500 hover:underline"
+                        onClick={e => e.stopPropagation()}
+                      >
+                        Logs
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </Fragment>
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
This PR addresses #119 by consolidating multi-container pods into a single "rolled-up" view on the Pod Resources page.

### Key Changes:
- **Grouped View**: Containers are now grouped by Pod by default.
- **Resource Aggregation**: Total CPU and Memory requests/limits are aggregated at the pod level.
- **Expandable Rows**: Added a chevron-toggle UI to expand/collapse pods to see individual container metrics.
- **Improved Parsing**: Added robust parsing for K8s resource strings (`m`, `Ki`, `Mi`, etc.) to support accurate aggregation.
- **Maintained Functionality**: Individual container logs are still accessible via the expanded view.

Closes #119