### PR TITLE
fix: improve pod status detection in pod resources page

### DIFF
--- a/src/app/tools/k8s-pod-resources/page.tsx
+++ b/src/app/tools/k8s-pod-resources/page.tsx
@@ -116,7 +116,7 @@ function PodResourcesTable({ data, namespace }: { data: PodResource[], namespace
                   <td className="px-4 py-3">
                     <span className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${
                       group.status === 'Running' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
-                      group.status === 'Pending' ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' :
+                      (group.status === 'Pending' || group.status === 'ContainerCreating' || group.status === 'PodInitializing') ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' :
                       'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
                     }`}>
                       {group.status}

--- a/src/lib/k8s.ts
+++ b/src/lib/k8s.ts
@@ -101,6 +101,19 @@ export async function getPods(namespace: string, context?: string) {
   return podsResp.items.flatMap((pod: V1Pod) =>
     (pod.spec?.containers || []).map((container) => {
       const resources = container.resources || {};
+      
+      // Calculate detailed status
+      let status = pod.status?.phase || "Unknown";
+      const containerStatus = pod.status?.containerStatuses?.find(cs => cs.name === container.name);
+      
+      if (containerStatus?.state?.waiting) {
+        status = containerStatus.state.waiting.reason || "Waiting";
+      } else if (containerStatus?.state?.terminated) {
+        status = containerStatus.state.terminated.reason || "Terminated";
+      } else if (containerStatus?.lastState?.terminated && !containerStatus.ready) {
+        status = containerStatus.lastState.terminated.reason || "Error";
+      }
+
       return {
         podName: pod.metadata?.name || "",
         containerName: container.name,
@@ -108,7 +121,7 @@ export async function getPods(namespace: string, context?: string) {
         cpuLimit: resources.limits?.cpu || "-",
         memoryRequest: resources.requests?.memory || "-",
         memoryLimit: resources.limits?.memory || "-",
-        status: pod.status?.phase,
+        status,
         labels: pod.metadata?.labels || {},
         nodeName: pod.spec?.nodeName,
       };


### PR DESCRIPTION
### Summary
This PR improves the pod status detection logic in the Pod Resources page. Previously, it relied solely on `pod.status.phase`, which often reported "Running" even if containers were in a `CrashLoopBackOff` or `Pending` state (like `ContainerCreating`).

### Changes
- **Backend ([src/lib/k8s.ts](src/lib/k8s.ts))**: Updated `getPods()` to inspect `containerStatuses`. It now prioritizes `waiting` and `terminated` states, providing much more accurate status reporting (e.g., `CrashLoopBackOff`, `ImagePullBackOff`, `ContainerCreating`).
- **Frontend ([src/app/tools/k8s-pod-resources/page.tsx](src/app/tools/k8s-pod-resources/page.tsx))**: Updated the status badge logic to handle intermediate states like `ContainerCreating` and `PodInitializing` with the appropriate warning colors.

Fixes #131 
Closes #131