### PR TITLE
fix: persist json modal and description states during background refreshes

### DIFF
--- a/src/app/k8s-dashboard/DashboardContent.tsx
+++ b/src/app/k8s-dashboard/DashboardContent.tsx
@@ -409,7 +409,7 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
           _memLimVal: 0,
         };
       }
-      
+
       const cpuReq = parseCpu(String(item.cpuRequest || '-'));
       const cpuLim = parseCpu(String(item.cpuLimit || '-'));
       const memReq = parseMemory(String(item.memoryRequest || '-'));
@@ -419,7 +419,7 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
       pods[podName]._cpuLimVal += cpuLim;
       pods[podName]._memReqVal += memReq;
       pods[podName]._memLimVal += memLim;
-      
+
       pods[podName].subRows.push({
         ...item,
         subRows: undefined,
@@ -434,19 +434,19 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
           return { ...pod.subRows[0], subRows: undefined };
         }
 
-      return {
-        ...pod,
-        cpuRequest: formatCpu(pod._cpuReqVal),
-        cpuLimit: formatCpu(pod._cpuLimVal),
-        memoryRequest: formatMemory(pod._memReqVal),
-        memoryLimit: formatMemory(pod._memLimVal),
-        containerName: `${pod.subRows.length} containers`,
-      };
-    });
+        return {
+          ...pod,
+          cpuRequest: formatCpu(pod._cpuReqVal),
+          cpuLimit: formatCpu(pod._cpuLimVal),
+          memoryRequest: formatMemory(pod._memReqVal),
+          memoryLimit: formatMemory(pod._memLimVal),
+          containerName: `${pod.subRows.length} containers`,
+        };
+      });
   }, [data, tool]);
 
-  // Determine columns from ALL items to handle sparse data
-  const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(() => {
+  // Determine column keys from ALL items to handle sparse data
+  const columnKeysStr = useMemo(() => {
     const allKeys = new Set<string>();
     // Use processedData to ensure all keys are shown
     processedData.forEach((item) => {
@@ -456,10 +456,13 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
         }
       });
     });
+    return Array.from(allKeys).sort().join(',');
+  }, [processedData]);
 
-    const cols = Array.from(allKeys);
-    const nameCols = cols.filter((c) => c.toLowerCase().includes("name"));
-    const otherCols = cols.filter((c) => !c.toLowerCase().includes("name"));
+  const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(() => {
+    const columnKeys = columnKeysStr ? columnKeysStr.split(',') : [];
+    const nameCols = columnKeys.filter((c) => c.toLowerCase().includes("name"));
+    const otherCols = columnKeys.filter((c) => !c.toLowerCase().includes("name"));
     const sortedColumns = [...nameCols, ...otherCols];
 
     const baseCols: ColumnDef<Record<string, unknown>>[] = sortedColumns.map((key) => ({
@@ -661,7 +664,7 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
     });
 
     return baseCols;
-  }, [processedData, tool, namespace, handleStopPortForward, addAttachment]);
+  }, [columnKeysStr, tool, namespace, handleStopPortForward, addAttachment]);
 
   const table = useReactTable({
     data: processedData,
@@ -716,7 +719,7 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
           </TableHeader>
           <TableBody>
             {table.getRowModel().rows.map((row) => (
-              <TableRow 
+              <TableRow
                 key={row.id}
                 className={cn(
                   row.depth > 0 ? "bg-zinc-50/50 dark:bg-zinc-800/20 border-l-4 border-l-blue-500/30" : "hover:bg-zinc-50 dark:hover:bg-zinc-800/50",
@@ -727,7 +730,7 @@ function ResourceTable({ data, tool, namespace }: { data: Record<string, unknown
                 {row.getVisibleCells().map((cell) => {
                   const val = cell.getValue();
                   const isObject = typeof val === "object" && val !== null;
-                  
+
                   return (
                     <TableCell
                       key={cell.id}

--- a/src/lib/refresh-context.tsx
+++ b/src/lib/refresh-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback, useMemo } from 'react';
 
 interface RefreshContextType {
   autoRefresh: boolean;
@@ -34,34 +34,34 @@ export function RefreshProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const setAutoRefresh = (val: boolean) => {
+  const setAutoRefresh = useCallback((val: boolean) => {
     setAutoRefreshState(val);
     localStorage.setItem('k8s-auto-refresh', String(val));
-  };
+  }, []);
 
-  const setInterval = (val: number) => {
+  const setInterval = useCallback((val: number) => {
     setIntervalState(val);
     localStorage.setItem('k8s-refresh-interval', String(val));
-  };
+  }, []);
 
-  const refresh = () => {
+  const refresh = useCallback(() => {
     setTriggerRefresh(prev => prev + 1);
     setLastUpdated(new Date());
-  };
+  }, []);
+
+  const contextValue = useMemo(() => ({
+    autoRefresh,
+    setAutoRefresh,
+    interval,
+    setInterval,
+    lastUpdated,
+    setLastUpdated,
+    triggerRefresh,
+    refresh
+  }), [autoRefresh, setAutoRefresh, interval, setInterval, lastUpdated, triggerRefresh, refresh]);
 
   return (
-    <RefreshContext.Provider 
-      value={{ 
-        autoRefresh, 
-        setAutoRefresh, 
-        interval, 
-        setInterval, 
-        lastUpdated, 
-        setLastUpdated,
-        triggerRefresh,
-        refresh
-      }}
-    >
+    <RefreshContext.Provider value={contextValue}>
       {children}
     </RefreshContext.Provider>
   );


### PR DESCRIPTION
Fixes #127

Changes:
1. Re-implemented the `columns` definition in `DashboardContent.tsx` to depend strictly on the extracted column property names (`columnKeysStr`), rather than the list array instance itself. This prevents React Table from unnecessarily destroying and rebuilding DOM cell nodes when polling fetches update existing resources.
2. Memoized the export functions in `refresh-context.tsx` (`setInterval`, `setAutoRefresh`, `refresh`) via `useCallback` to maintain their identity and prevent redundant cascading re-renders across consumers.

These performance optimizations preserve the JSON modal DOM elements allowing their states to endure across background refreshes while also transparently receiving the new data.