### PR TITLE
feat: add Qwen, SmolLM, and Llama 3.2 1B to local browser models

### DIFF
--- a/src/components/ChatComponent.tsx
+++ b/src/components/ChatComponent.tsx
@@ -69,6 +69,11 @@ function ChatComponentInner({
     "gpt-4o": "GPT-4o",
     "claude-3.5-sonnet": "Claude 3.5",
     "o1-mini": "o1 Mini",
+    "Llama-3.2-1B-Instruct-q4f16_1-MLC": "Llama 3.2 (1B Local)",
+    "SmolLM-360M-q016-MLC": "SmolLM (360M Local)",
+    "Qwen3-1.7B-q4f16_1-MLC": "Qwen 3 (1.7B Local)",
+    "Qwen2.5-7B-Instruct-q4f16_1-MLC": "Qwen 2.5 (7B Local)",
+    "Qwen2.5-14B-Instruct_q4f16_1-MLC": "Qwen 2.5 (14B Local)",
     "Hermes-3-Llama-3.1-8B-q4f32_1-MLC": "Hermes 3 (Llama 8B)",
     "Hermes-2-Pro-Llama-3-8B-q4f32_1-MLC": "Hermes 2 Pro (Llama 8B)",
   };
@@ -111,6 +116,11 @@ function ChatComponentInner({
             if (typeof navigator !== "undefined" && (navigator as any).gpu) {
               models = [
                 ...models,
+                { id: "Llama-3.2-1B-Instruct-q4f16_1-MLC", name: "Llama-3.2-1B (Browser)", isLocal: true },
+                { id: "SmolLM-360M-q016-MLC", name: "SmolLM-360M (Browser)", isLocal: true },
+                { id: "Qwen3-1.7B-q4f16_1-MLC", name: "Qwen3-1.7B (Browser)", isLocal: true },
+                { id: "Qwen2.5-7B-Instruct-q4f16_1-MLC", name: "Qwen2.5-7B (Browser)", isLocal: true },
+                { id: "Qwen2.5-14B-Instruct_q4f16_1-MLC", name: "Qwen2.5-14B (Browser)", isLocal: true },
                 { id: "Hermes-3-Llama-3.1-8B-q4f32_1-MLC", name: "Hermes-3-Llama-3.1-8B (Browser)", isLocal: true },
                 { id: "Hermes-2-Pro-Llama-3-8B-q4f32_1-MLC", name: "Hermes-2-Pro-Llama-3-8B (Browser)", isLocal: true },
               ];
@@ -128,7 +138,7 @@ function ChatComponentInner({
   useEffect(() => {
     async function fetchTools() {
       try {
-        const res = await fetch(`/api/tools/schema?isReadOnly=${isReadOnly}`);
+        const res = await fetch(`/api/tools/schema?isReadOnly=\${isReadOnly}`);
         if (res.ok) {
           const data = await res.json();
           setTools(data.tools || []);

--- a/src/components/WebLLMProvider.tsx
+++ b/src/components/WebLLMProvider.tsx
@@ -40,8 +40,41 @@ export const WebLLMProvider = ({ children }: { children: ReactNode }) => {
             setProgress(null);
 
             // Initialize engine
-            console.log(`[WebLLM] Requesting load for model: ${modelId}`);
-            const mlcEngine = new webllm.MLCEngine();
+            console.log(`[WebLLM] Requesting load for model: \${modelId}`);
+            
+            // Custom model list for Qwen and other small models
+            const appConfig: webllm.AppConfig = {
+                model_list: [
+                    ...webllm.prebuiltAppConfig.model_list.filter(m => 
+                        m.model_id.startsWith('Qwen2.5-7B') ||
+                        (m.model_id.startsWith('Llama-3.1-8B-') && !m.model_id.endsWith('-1k')) ||
+                        m.model_id.startsWith('Llama-3.2-1B') ||
+                        m.model_id.startsWith('Hermes-3-Llama-3.1') ||
+                        m.model_id.startsWith('Qwen3-1.7B') ||
+                        m.model_id.startsWith('Qwen3-4B') ||
+                        m.model_id.startsWith('Qwen3-8B')
+                    ),
+                    {
+                        model: "https://huggingface.co/smalinin/Qwen2.5-14B-Instruct_q4f16_1-MLC",
+                        model_id: "Qwen2.5-14B-Instruct_q4f16_1-MLC",
+                        model_lib: "https://huggingface.co/smalinin/Qwen2.5-14B-Instruct_q4f16_1-MLC/resolve/main/Qwen2.5-14B-Instruct_q4f16_1-webgpu.wasm",
+                        low_resource_required: false,
+                        vram_required_MB: 10900.0,
+                        required_features: ["shader-f16"],
+                        overrides: {
+                            context_window_size: 4096,
+                        },
+                    },
+                    {
+                        model: "https://huggingface.co/cfahlgren1/SmolLM-360M-q016-MLC",
+                        model_id: "SmolLM-360M-q016-MLC",
+                        model_lib: `\${webllm.modelLibURLPrefix}\${webllm.modelVersion}/SmolLM-360M-Instruct-q0f16-ctx2k_cs1k-webgpu.wasm`,
+                        overrides: { context_window_size: 2048 },
+                    }
+                ]
+            };
+
+            const mlcEngine = new webllm.MLCEngine({ appConfig });
 
             mlcEngine.setInitProgressCallback((p: webllm.InitProgressReport) => {
                 console.log(`[WebLLM Progress]`, p);
@@ -49,7 +82,7 @@ export const WebLLMProvider = ({ children }: { children: ReactNode }) => {
             });
 
             await mlcEngine.reload(modelId);
-            console.log(`[WebLLM] Successfully loaded model: ${modelId}`);
+            console.log(`[WebLLM] Successfully loaded model: \${modelId}`);
 
             engineRef.current = mlcEngine;
             setEngine(mlcEngine);


### PR DESCRIPTION
This PR adds several smaller LLM models to the local WebLLM browser-based engine. 

### Changes:
- **Models Added**:
  - **Qwen**: Qwen3 (1.7B, 4B, 8B variants) and Qwen2.5 (7B, 14B variants).
  - **SmolLM**: SmolLM-360M for ultra-lightweight local use.
  - **Llama 3.2**: Llama 3.2 1B variant.
- **WebLLMProvider**: Updated `loadModel` to use a custom `appConfig` with filtered prebuilt models and manual Hugging Face configurations for Qwen 14B and SmolLM.
- **ChatComponent**: Updated `MODEL_DISPLAY_NAMES` and the local model detection logic to showcase these new options in the UI.

These models run entirely in the browser using WebGPU, providing a private and cost-effective alternative to server-side LLMs when a compatible GPU is present.